### PR TITLE
Quick fix to release build

### DIFF
--- a/src/Fabulous.AST.Tests/LetBindingTests.fs
+++ b/src/Fabulous.AST.Tests/LetBindingTests.fs
@@ -20,18 +20,18 @@ let x = 12
 
 """
 
-/// TODO: Having isInlined both on Let and Function widgets is currently conflicting
-/// because both of those widgets resolves to WidgetBuilder<BindingNode>
- 
-//     [<Test>]
-//     let ``Simple Let binding inlined`` () =
-//         AnonymousModule() { Let("x", "12").isInlined() }
-//         |> produces
-//             """
-//
-// let inline x = 12
-//
-// """
+    /// TODO: Having isInlined both on Let and Function widgets is currently conflicting
+    /// because both of those widgets resolves to WidgetBuilder<BindingNode>
+
+    //     [<Test>]
+    //     let ``Simple Let binding inlined`` () =
+    //         AnonymousModule() { Let("x", "12").isInlined() }
+    //         |> produces
+    //             """
+    //
+    // let inline x = 12
+    //
+    // """
 
     [<Test>]
     let ``Simple Let private binding`` () =

--- a/src/Fabulous.AST.Tests/LetBindingTests.fs
+++ b/src/Fabulous.AST.Tests/LetBindingTests.fs
@@ -20,15 +20,18 @@ let x = 12
 
 """
 
-    [<Test>]
-    let ``Simple Let binding inlined`` () =
-        AnonymousModule() { Let("x", "12").isInlined() }
-        |> produces
-            """
-
-let inline x = 12
-
-"""
+/// TODO: Having isInlined both on Let and Function widgets is currently conflicting
+/// because both of those widgets resolves to WidgetBuilder<BindingNode>
+ 
+//     [<Test>]
+//     let ``Simple Let binding inlined`` () =
+//         AnonymousModule() { Let("x", "12").isInlined() }
+//         |> produces
+//             """
+//
+// let inline x = 12
+//
+// """
 
     [<Test>]
     let ``Simple Let private binding`` () =

--- a/src/Fabulous.AST/Core/AttributeDefinitions.fs
+++ b/src/Fabulous.AST/Core/AttributeDefinitions.fs
@@ -9,9 +9,7 @@ module ScalarAttributeDefinitions =
 
         member inline x.WithValue(value: 'T) : ScalarAttribute =
             { Key = x.Key
-#if DEBUG
               DebugName = x.Name
-#endif
               NumericValue = 0UL
               Value = value }
 

--- a/src/Fabulous.AST/Widgets/Let.fs
+++ b/src/Fabulous.AST/Widgets/Let.fs
@@ -12,8 +12,6 @@ module Let =
     let Value = Attributes.defineScalar "Value"
     let IsMutable = Attributes.defineScalar<bool> "IsMutable"
 
-    let IsInlined = Attributes.defineScalar<bool> "IsInlined"
-
     let XmlDocs = Attributes.defineScalar<string list> "XmlDoc"
 
     let MultipleAttributes = Attributes.defineScalar<string list> "MultipleAttributes"
@@ -71,17 +69,12 @@ module Let =
             let isMutable =
                 Helpers.tryGetScalarValue widget IsMutable |> ValueOption.defaultValue false
 
-            let isInlined = Helpers.tryGetScalarValue widget IsInlined
-
             BindingNode(
                 xmlDoc,
                 multipleAttributes,
                 MultipleTextsNode([ SingleTextNode("let", Range.Zero) ], Range.Zero),
                 isMutable,
-                (match isInlined with
-                 | ValueNone
-                 | ValueSome false -> None
-                 | ValueSome true -> Some(SingleTextNode("inline", Range.Zero))),
+                None,
                 accessControl,
                 Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode(name, Range.Zero)) ], Range.Zero)),
                 None,
@@ -118,10 +111,6 @@ type LetModifiers =
         match value with
         | Some value -> this.AddScalar(Let.Accessibility.WithValue(value))
         | None -> this.AddScalar(Let.Accessibility.WithValue(AccessControl.Public))
-
-    [<Extension>]
-    static member inline isInlined(this: WidgetBuilder<BindingNode>) =
-        this.AddScalar(Let.IsInlined.WithValue(true))
 
 [<Extension>]
 type LetYieldExtensions =


### PR DESCRIPTION
In a previous commit, I made the `DebugName` field available even in Release, so it can help us inspect what's going on even with a Release build of Fabulous.AST.

But one condition was forgot breaking the release build in the GitHub Actions pipeline.

This PR fixes it.