### PR TITLE
Add support for single child widgets and prefixed modifiers

### DIFF
--- a/src/Fabulous.AST.Tests/AnonymousModuleTests.fs
+++ b/src/Fabulous.AST.Tests/AnonymousModuleTests.fs
@@ -63,9 +63,7 @@ if x = 12 then
     [<Test>]
     let ``Produces FizzBuzz`` () =
         AnonymousModule() {
-            Function(
-                "fizzBuzz",
-                [| "i" |],
+            Function("fizzBuzz", [| "i" |]) {
                 Match(Expr.For("i")) {
                     MatchClause(
                         "i",
@@ -87,7 +85,7 @@ if x = 12 then
 
                     MatchClause("i", Call("printfn", "\"%i\"", "i"))
                 }
-            )
+            }
         }
         |> produces
             """
@@ -104,9 +102,7 @@ let fizzBuzz i =
     [<Test>]
     let ``Produces inlined FizzBuzz`` () =
         AnonymousModule() {
-            Function(
-                "fizzBuzz",
-                [| "i" |],
+            Function("fizzBuzz", [| "i" |]).isInlined() {
                 Match(Expr.For("i")) {
                     MatchClause(
                         "i",
@@ -128,8 +124,7 @@ let fizzBuzz i =
 
                     MatchClause("i", Call("printfn", "\"%i\"", "i"))
                 }
-            )
-                .isInlined()
+            }
         }
         |> produces
             """

--- a/src/Fabulous.AST.Tests/NestedModuleTests.fs
+++ b/src/Fabulous.AST.Tests/NestedModuleTests.fs
@@ -51,7 +51,7 @@ module A =
 
     [<Test>]
     let ``Produces a recursive NestedModule`` () =
-        (NestedModule("A") { Let("x", "12") }).isRecursive()
+        NestedModule("A").isRecursive() { Let("x", "12") }
         |> produces
             """
 
@@ -62,7 +62,7 @@ module rec A =
 
     [<Test>]
     let ``Produces a private NestedModule`` () =
-        (NestedModule("A") { Let("x", "12") }).accessibility(AccessControl.Private)
+        NestedModule("A").accessibility(AccessControl.Private) { Let("x", "12") }
         |> produces
             """
 
@@ -73,7 +73,7 @@ module private A =
 
     [<Test>]
     let ``Produces a internal NestedModule`` () =
-        (NestedModule("A") { Let("x", "12") }).accessibility(AccessControl.Internal)
+        NestedModule("A").accessibility(AccessControl.Internal) { Let("x", "12") }
         |> produces
             """
 

--- a/src/Fabulous.AST/Widgets/Call.fs
+++ b/src/Fabulous.AST/Widgets/Call.fs
@@ -44,9 +44,9 @@ type CallYieldExtensions =
         (
             _: CollectionBuilder<ModuleOrNamespaceNode, ModuleDecl>,
             x: WidgetBuilder<Expr>
-        ) : Content =
+        ) : CollectionContent =
         { Widgets = MutStackArray1.One(DeclExpr(x).Compile()) }
 
     [<Extension>]
-    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, x: WidgetBuilder<Expr>) : Content =
+    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, x: WidgetBuilder<Expr>) : CollectionContent =
         { Widgets = MutStackArray1.One(DeclExpr(x).Compile()) }

--- a/src/Fabulous.AST/Widgets/EscapeHatch.fs
+++ b/src/Fabulous.AST/Widgets/EscapeHatch.fs
@@ -24,5 +24,5 @@ module EscapeHatchBuilders =
 [<Extension>]
 type EscapeHatchYieldExtensions =
     [<Extension>]
-    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, x: BindingNode) : Content =
+    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, x: BindingNode) : CollectionContent =
         { Widgets = MutStackArray1.One(Ast.TopLevelBinding(Ast.EscapeHatch(x)).Compile()) }

--- a/src/Fabulous.AST/Widgets/Function.fs
+++ b/src/Fabulous.AST/Widgets/Function.fs
@@ -45,12 +45,13 @@ module Function =
 module FunctionBuilders =
     type Fabulous.AST.Ast with
 
-        static member inline Function(name: string, parameters: string[], bodyExpr: WidgetBuilder<Expr>) =
-            WidgetBuilder<BindingNode>(
+        static member inline Function(name: string, parameters: string[]) =
+            SingleChildBuilder<BindingNode, Expr>(
                 Function.WidgetKey,
+                Function.BodyExpr,
                 AttributesBundle(
                     StackList.two(Function.Name.WithValue(name), Function.Parameters.WithValue(parameters)),
-                    ValueSome [| Function.BodyExpr.WithValue(bodyExpr.Compile()) |],
+                    ValueNone,
                     ValueNone
                 )
             )
@@ -58,5 +59,5 @@ module FunctionBuilders =
 [<Extension>]
 type FunctionModifiers =
     [<Extension>]
-    static member inline isInlined(this: WidgetBuilder<BindingNode>) =
+    static member inline isInlined(this: SingleChildBuilder<BindingNode, Expr>) =
         this.AddScalar(Function.IsInlined.WithValue(true))

--- a/src/Fabulous.AST/Widgets/Let.fs
+++ b/src/Fabulous.AST/Widgets/Let.fs
@@ -115,5 +115,9 @@ type LetModifiers =
 [<Extension>]
 type LetYieldExtensions =
     [<Extension>]
-    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, x: WidgetBuilder<BindingNode>) : Content =
+    static member inline Yield
+        (
+            _: CollectionBuilder<'parent, ModuleDecl>,
+            x: WidgetBuilder<BindingNode>
+        ) : CollectionContent =
         { Widgets = MutStackArray1.One(TopLevelBinding(x).Compile()) }

--- a/src/Fabulous.AST/Widgets/Match.fs
+++ b/src/Fabulous.AST/Widgets/Match.fs
@@ -34,9 +34,12 @@ module MatchBuilders =
         static member inline Match(matchExpr: WidgetBuilder<Expr>) =
             CollectionBuilder<Expr, MatchClauseNode>(
                 Match.WidgetKey,
-                StackList.empty(),
-                ValueSome [| Match.MatchExpr.WithValue(matchExpr.Compile()) |],
-                Match.MatchClauses
+                Match.MatchClauses,
+                AttributesBundle(
+                    StackList.empty(),
+                    ValueSome [| Match.MatchExpr.WithValue(matchExpr.Compile()) |],
+                    ValueNone
+                )
             )
 
 [<Extension>]
@@ -46,5 +49,5 @@ type MatchYieldExtensions =
         (
             _: CollectionBuilder<Expr, MatchClauseNode>,
             x: WidgetBuilder<MatchClauseNode>
-        ) : Content =
+        ) : CollectionContent =
         { Widgets = MutStackArray1.One(x.Compile()) }

--- a/src/Fabulous.AST/Widgets/NestedModule.fs
+++ b/src/Fabulous.AST/Widgets/NestedModule.fs
@@ -70,11 +70,9 @@ module NestedModuleBuilders =
 [<Extension>]
 type NestedModuleModifiers =
     [<Extension>]
-    static member inline isRecursive(this: WidgetBuilder<Oak>) =
+    static member inline isRecursive(this: CollectionBuilder<Oak, ModuleDecl>) =
         this.AddScalar(NestedModule.IsRecursive.WithValue(true))
 
     [<Extension>]
-    static member inline accessibility(this: WidgetBuilder<Oak>, ?value: AccessControl) =
-        match value with
-        | Some value -> this.AddScalar(NestedModule.Accessibility.WithValue(value))
-        | None -> this.AddScalar(NestedModule.Accessibility.WithValue(AccessControl.Public))
+    static member inline accessibility(this: CollectionBuilder<Oak, ModuleDecl>, value: AccessControl) =
+        this.AddScalar(NestedModule.Accessibility.WithValue(value))

--- a/src/Fabulous.AST/Widgets/Oak.fs
+++ b/src/Fabulous.AST/Widgets/Oak.fs
@@ -31,5 +31,5 @@ type OakYieldExtensions =
         (
             _: CollectionBuilder<Oak, ModuleOrNamespaceNode>,
             x: WidgetBuilder<ModuleOrNamespaceNode>
-        ) : Content =
+        ) : CollectionContent =
         { Widgets = MutStackArray1.One(x.Compile()) }


### PR DESCRIPTION
This PR enables 2 new syntaxes regarding the computation expressions used in the DSL.

### Single child

Before widgets taking a single child would be required to accept it as a constructor parameter whereas those taking several children would rely on a custom CE builder. This PR introduces the possibility to also use the CE syntax for single child widgets using implicit yield. Subsequent implicit yields will report a build error to ensure safety.

```fs
// Before
Function(
    "fizzBuzz",
    [| "i" |],
    Match(...)
)

// After
Function("fizzBuzz", [| "i" |]) {
    Match(...)
}
```

### Prefixed modifiers on CE builders

Previously it was only possible to add modifiers to collection widgets when adding parenthesis around the CE and its body. This PR also allows to add modifiers before the CE's body.

```fs
// Before
(NestedModule("A") {
     Let("x", "12") 
})
    .accessibility(AccessControl.Private)

// After
NestedModule("A")
    .accessibility(AccessControl.Private) {
    Let("x", "12")
}
```
