### PR TITLE
Open & OpenType widgets support

### DIFF
--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -13,6 +13,8 @@
         <Compile Include="LetBindingTests.fs" />
         <Compile Include="AnonymousModuleTests.fs" />
         <Compile Include="NestedModuleTests.fs" />
+        <Compile Include="OpenDirectives\OpenTests.fs" />
+        <Compile Include="OpenDirectives\OpenTypeTests.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/src/Fabulous.AST.Tests/OpenDirectives/OpenTests.fs
+++ b/src/Fabulous.AST.Tests/OpenDirectives/OpenTests.fs
@@ -1,0 +1,41 @@
+namespace Fabulous.AST.Tests
+
+open FSharp.Compiler.Text
+open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+open NUnit.Framework
+
+open Fabulous.AST
+
+open type Ast
+
+module OpenTests =
+
+    [<Test>]
+    let ``Produces a simple open directive from a string`` () =
+        AnonymousModule() { Open("ABC") }
+        |> produces
+            """
+
+open ABC
+
+"""
+
+    [<Test>]
+    let ``Produces an open directive from a node`` () =
+        AnonymousModule() {
+            Open(
+                IdentListNode(
+                    [ IdentifierOrDot.Ident(SingleTextNode("ABC", Range.Zero))
+                      IdentifierOrDot.KnownDot(SingleTextNode(".", Range.Zero))
+                      IdentifierOrDot.Ident(SingleTextNode("DEF", Range.Zero)) ],
+                    Range.Zero
+                )
+            )
+        }
+        |> produces
+            """
+
+open ABC.DEF
+
+"""

--- a/src/Fabulous.AST.Tests/OpenDirectives/OpenTypeTests.fs
+++ b/src/Fabulous.AST.Tests/OpenDirectives/OpenTypeTests.fs
@@ -1,0 +1,43 @@
+namespace Fabulous.AST.Tests
+
+open FSharp.Compiler.Text
+open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+open NUnit.Framework
+
+open Fabulous.AST
+
+open type Ast
+
+module OpenTypeTests =
+
+    [<Test>]
+    let ``Produces a simple open type directive from a string`` () =
+        AnonymousModule() { OpenType("ABC") }
+        |> produces
+            """
+
+open type ABC
+
+"""
+
+    [<Test>]
+    let ``Produces an open type directive from a node`` () =
+        AnonymousModule() {
+            OpenType(
+                IdentListNode(
+                    [ IdentifierOrDot.Ident(SingleTextNode("Fabulous", Range.Zero))
+                      IdentifierOrDot.KnownDot(SingleTextNode(".", Range.Zero))
+                      IdentifierOrDot.Ident(SingleTextNode("Avalonia", Range.Zero))
+                      IdentifierOrDot.KnownDot(SingleTextNode(".", Range.Zero))
+                      IdentifierOrDot.Ident(SingleTextNode("View", Range.Zero)) ],
+                    Range.Zero
+                )
+            )
+        }
+        |> produces
+            """
+
+open type Fabulous.Avalonia.View
+
+"""

--- a/src/Fabulous.AST.Tests/WidgetTests.fs
+++ b/src/Fabulous.AST.Tests/WidgetTests.fs
@@ -13,7 +13,7 @@ module WidgetTests =
         let source =
             """
 
-let mutable x = 10
+open type ABC
 
 """
 

--- a/src/Fabulous.AST/Fabulous.AST.fsproj
+++ b/src/Fabulous.AST/Fabulous.AST.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="Core\Helpers.fs" />
         <Compile Include="Core\Widgets.fs" />
         <Compile Include="Core\Attributes.fs" />
+        <Compile Include="Tree.fs" />
         <Compile Include="Widgets\Common.fs" />
         <Compile Include="Widgets\Glue.fs" />
         <Compile Include="Widgets\Oak.fs" />
@@ -29,7 +30,8 @@
         <Compile Include="Widgets\EscapeHatch.fs" />
         <Compile Include="Widgets\Namespaces\AnonymousModule.fs" />
         <Compile Include="Widgets\Namespaces\Namespace.fs" />
-        <Compile Include="Tree.fs" />
+        <Compile Include="Widgets\OpenDirectives\Open.fs" />
+        <Compile Include="Widgets\OpenDirectives\OpenType.fs" />
         <None Include="test.fsx" />
     </ItemGroup>
 

--- a/src/Fabulous.AST/Widgets/EscapeHatch.fs
+++ b/src/Fabulous.AST/Widgets/EscapeHatch.fs
@@ -6,7 +6,7 @@ open Fantomas.Core.SyntaxOak
 
 // This widget holds a direct reference to a manually created node so it can be composed in the widget tree
 module EscapeHatch =
-    let Node = Attributes.defineScalar<NodeBase> "Node"
+    let Node = Attributes.defineScalar<obj> "Node"
 
     let WidgetKey =
         Widgets.register "EscapeHatch" (fun widget ->
@@ -18,7 +18,7 @@ module EscapeHatch =
 module EscapeHatchBuilders =
     type Fabulous.AST.Ast with
 
-        static member inline EscapeHatch<'T when 'T :> NodeBase>(node: 'T) =
+        static member inline EscapeHatch(node: 'T) =
             WidgetBuilder<'T>(EscapeHatch.WidgetKey, EscapeHatch.Node.WithValue(node))
 
 [<Extension>]

--- a/src/Fabulous.AST/Widgets/OpenDirectives/Open.fs
+++ b/src/Fabulous.AST/Widgets/OpenDirectives/Open.fs
@@ -1,0 +1,51 @@
+namespace Fabulous.AST
+
+open System.Runtime.CompilerServices
+open FSharp.Compiler.Text
+open Fabulous.AST.StackAllocatedCollections
+open Fabulous.AST.StackAllocatedCollections.StackList
+open Fantomas.Core.SyntaxOak
+
+type OpenNode(identListNode: IdentListNode) =
+    inherit OpenModuleOrNamespaceNode(identListNode, Range.Zero)
+
+module Open =
+    let IdentList = Attributes.defineWidget "IdentList"
+
+    let WidgetKey =
+        Widgets.register "Open" (fun widget ->
+            let identList = Helpers.getNodeFromWidget<IdentListNode> widget IdentList
+            OpenNode identList)
+
+[<AutoOpen>]
+module OpenBuilders =
+    type Fabulous.AST.Ast with
+
+        static member inline Open(identList: WidgetBuilder<#IdentListNode>) =
+            WidgetBuilder<OpenNode>(
+                Open.WidgetKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    ValueSome [| Open.IdentList.WithValue(identList.Compile()) |],
+                    ValueNone
+                )
+            )
+
+        static member inline Open(node: IdentListNode) = Ast.Open(Ast.EscapeHatch(node))
+
+        static member inline Open(name: string) =
+            Ast.Open(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode(name, Range.Zero)) ], Range.Zero))
+
+[<Extension>]
+type OpenYieldExtensions =
+    [<Extension>]
+    static member inline Yield
+        (
+            _: CollectionBuilder<'parent, ModuleDecl>,
+            x: WidgetBuilder<OpenNode>
+        ) : CollectionContent =
+        let node = Tree.compile x
+        let openList = OpenListNode([ Open.ModuleOrNamespace node ])
+        let moduleDecl = ModuleDecl.OpenList openList
+        let widget = Ast.EscapeHatch(moduleDecl).Compile()
+        { Widgets = MutStackArray1.One(widget) }

--- a/src/Fabulous.AST/Widgets/OpenDirectives/OpenType.fs
+++ b/src/Fabulous.AST/Widgets/OpenDirectives/OpenType.fs
@@ -1,0 +1,51 @@
+namespace Fabulous.AST
+
+open System.Runtime.CompilerServices
+open FSharp.Compiler.Text
+open Fabulous.AST.StackAllocatedCollections
+open Fabulous.AST.StackAllocatedCollections.StackList
+open Fantomas.Core.SyntaxOak
+
+type OpenTypeNode(target: IdentListNode) =
+    inherit OpenTargetNode(Type.LongIdent target, Range.Zero)
+
+module OpenType =
+    let Target = Attributes.defineWidget "Target"
+
+    let WidgetKey =
+        Widgets.register "OpenType" (fun widget ->
+            let target = Helpers.getNodeFromWidget<IdentListNode> widget Target
+            OpenTypeNode target)
+
+[<AutoOpen>]
+module OpenTypeBuilders =
+    type Fabulous.AST.Ast with
+
+        static member inline OpenType(identList: WidgetBuilder<#IdentListNode>) =
+            WidgetBuilder<OpenTypeNode>(
+                OpenType.WidgetKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    ValueSome [| OpenType.Target.WithValue(identList.Compile()) |],
+                    ValueNone
+                )
+            )
+
+        static member inline OpenType(node: IdentListNode) = Ast.OpenType(Ast.EscapeHatch(node))
+
+        static member inline OpenType(name: string) =
+            Ast.OpenType(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode(name, Range.Zero)) ], Range.Zero))
+
+[<Extension>]
+type OpenTypeYieldExtensions =
+    [<Extension>]
+    static member inline Yield
+        (
+            _: CollectionBuilder<'parent, ModuleDecl>,
+            x: WidgetBuilder<OpenTypeNode>
+        ) : CollectionContent =
+        let node = Tree.compile x
+        let openList = OpenListNode([ Open.Target node ])
+        let moduleDecl = ModuleDecl.OpenList openList
+        let widget = Ast.EscapeHatch(moduleDecl).Compile()
+        { Widgets = MutStackArray1.One(widget) }


### PR DESCRIPTION
Note this PR takes a different approach to "gluing" (eg. converting a `Let` widget to a `ModuleDecl.TopLevelBinding` so it could be yield inside a module/namespace).

Instead of creating plenty of glue widgets that are annoying to create, not really scalable and pollute the DSL, the glue is handled by implicit yield with the use of the `EscapeHatch` widget so we can combine widgets and Fantomas Oak code.

```fs
[<Extension>]
type OpenYieldExtensions =

    /// This implicit yield extension will convert a WidgetBuilder<OpenNode> to WidgetBuilder<ModuleDecl>
    [<Extension>]
    static member inline Yield
        (
            _: CollectionBuilder<'parent, ModuleDecl>,
            x: WidgetBuilder<OpenNode>
        ) : CollectionContent =
        let node = Tree.compile x
        let openList = OpenListNode([ Open.ModuleOrNamespace node ])
        let moduleDecl = ModuleDecl.OpenList openList
        let widget = Ast.EscapeHatch(moduleDecl).Compile()
        { Widgets = MutStackArray1.One(widget) }
```

I also think we need to normalise having 2 constructors for all widgets, one accepting a child widget and one accepting a Fantomas node (that will implicitly use the `EscapeHatch` widget).

```fs
[<AutoOpen>]
module OpenBuilders =
    type Fabulous.AST.Ast with

        static member inline Open(identList: WidgetBuilder<#IdentListNode>) =
            WidgetBuilder<OpenNode>(
                Open.WidgetKey,
                AttributesBundle(
                    StackList.empty(),
                    ValueSome [| Open.IdentList.WithValue(identList.Compile()) |],
                    ValueNone
                )
            )

        static member inline Open(node: IdentListNode) = Ast.Open(Ast.EscapeHatch(node))
```