### PR TITLE
Pin exact version of Fantomas.Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Changed
+* Target netstandard2.1
+* Use fixed version of Fantomas.Core
 
 ## [0.1.0]
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fantomas.Core" Version="6.0.0-alpha-010" />
+    <PackageVersion Include="Fantomas.Core" Version="[6.0.0-alpha-010]" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/src/Fabulous.AST/Fabulous.AST.fsproj
+++ b/src/Fabulous.AST/Fabulous.AST.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <IsPackable>true</IsPackable>
     </PropertyGroup>
     <!-- NuGet Package -->
@@ -56,7 +56,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Fantomas.Core" VersionOverride="[6.0.0-alpha-010, 6.0.0)" />
+        <PackageReference Include="Fantomas.Core"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Target netstandard2.1 instead.

I noticed you use quite some GitHub Actions logic to get the version from the changelog.
I find https://github.com/ionide/KeepAChangelog to be a bit more convenient as you can easily see that result locally.