### PR TITLE
Rename Let widget to Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Fabulous.AST is a powerful tool for anyone who works with code and wants to auto
 
 #### Let bindings
 
-| Widget          | Description           | F# code                         |
-|-----------------|-----------------------|---------------------------------|
-| Value           | A let binding         | ```let x = 12```                |
-| Constant        | A constant definition | ```[<Literal>] let x = 12```    |
-| Function        | A function definition | ```let f x = x + 1```           |
+| Widget   | Description           | F# code                         |
+|----------|-----------------------|---------------------------------|
+| Value    | A let binding         | ```let x = 12```                |
+| Literal  | A literal definition  | ```[<Literal>] let x = 12```    |
+| Function | A function definition | ```let f x = x + 1```           |
 
 #### Type definitions
 

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -15,7 +15,7 @@
         <Compile Include="Namespaces\NestedModule.fs" />
         <Compile Include="OpenDirectives\Open.fs" />
         <Compile Include="OpenDirectives\OpenType.fs" />
-        <Compile Include="LetBindings\Let.fs" />
+        <Compile Include="LetBindings\Value.fs" />
         <Compile Include="LetBindings\Literal.fs" />
         <Compile Include="LetBindings\Function.fs" />
         <Compile Include="TypeDefinitions\Union.fs" />

--- a/src/Fabulous.AST.Tests/LetBindings/Function.fs
+++ b/src/Fabulous.AST.Tests/LetBindings/Function.fs
@@ -1,4 +1,4 @@
-namespace Fabulous.AST.Tests.LetBinding
+namespace Fabulous.AST.Tests.LetBindings
 
 open Fabulous.AST
 

--- a/src/Fabulous.AST.Tests/LetBindings/Literal.fs
+++ b/src/Fabulous.AST.Tests/LetBindings/Literal.fs
@@ -1,4 +1,4 @@
-namespace Fabulous.AST.Tests.LetBinding
+namespace Fabulous.AST.Tests.LetBindings
 
 open FSharp.Compiler.Text
 open Fantomas.Core
@@ -10,6 +10,17 @@ open Fabulous.AST
 open type Ast
 
 module Literal =
+    [<Test>]
+    let ``Produces a Literal constant 2`` () =
+        AnonymousModule() { Literal("x", "12").xmlDocs([ "/// This is a comment" ]) }
+        |> produces
+            """
+/// This is a comment
+[<Literal>]
+let x = 12
+
+"""
+
     [<Test>]
     let ``Produces a Literal constant`` () =
         AnonymousModule() { Literal("x", "12") }

--- a/src/Fabulous.AST.Tests/LetBindings/Literal.fs
+++ b/src/Fabulous.AST.Tests/LetBindings/Literal.fs
@@ -11,17 +11,6 @@ open type Ast
 
 module Literal =
     [<Test>]
-    let ``Produces a Literal constant 2`` () =
-        AnonymousModule() { Literal("x", "12").xmlDocs([ "/// This is a comment" ]) }
-        |> produces
-            """
-/// This is a comment
-[<Literal>]
-let x = 12
-
-"""
-
-    [<Test>]
     let ``Produces a Literal constant`` () =
         AnonymousModule() { Literal("x", "12") }
         |> produces

--- a/src/Fabulous.AST.Tests/LetBindings/Value.fs
+++ b/src/Fabulous.AST.Tests/LetBindings/Value.fs
@@ -1,4 +1,4 @@
-namespace Fabulous.AST.Tests.LetBinding
+namespace Fabulous.AST.Tests.LetBindings
 
 open FSharp.Compiler.Text
 open Fantomas.Core
@@ -10,10 +10,10 @@ open Fabulous.AST
 
 open type Ast
 
-module Let =
+module Value =
     [<Test>]
     let ``Simple Let binding`` () =
-        AnonymousModule() { Let("x", "12") }
+        AnonymousModule() { Value("x", "12") }
         |> produces
             """
 
@@ -23,7 +23,7 @@ let x = 12
 
     [<Test>]
     let ``Simple Let binding inlined`` () =
-        AnonymousModule() { Let("x", "12").isInlined() }
+        AnonymousModule() { Value("x", "12").isInlined() }
         |> produces
             """
 
@@ -33,7 +33,7 @@ let inline x = 12
 
     [<Test>]
     let ``Simple Let private binding`` () =
-        AnonymousModule() { Let("x", "12").accessibility(AccessControl.Private) }
+        AnonymousModule() { Value("x", "12").accessibility(AccessControl.Private) }
         |> produces
             """
 
@@ -43,7 +43,7 @@ let private x = 12
 
     [<Test>]
     let ``Simple Let internal binding`` () =
-        AnonymousModule() { Let("x", "12").accessibility(AccessControl.Internal) }
+        AnonymousModule() { Value("x", "12").accessibility(AccessControl.Internal) }
         |> produces
             """
 
@@ -53,7 +53,7 @@ let internal x = 12
 
     [<Test>]
     let ``Simple Let binding with a single xml doc`` () =
-        AnonymousModule() { Let("x", "12").xmlDocs([ "/// This is a comment" ]) }
+        AnonymousModule() { Value("x", "12").xmlDocs([ "/// This is a comment" ]) }
         |> produces
             """
 
@@ -65,7 +65,7 @@ let x = 12
     [<Test>]
     let ``Simple Let binding with multiline xml doc`` () =
         AnonymousModule() {
-            Let("x", "12")
+            Value("x", "12")
                 .xmlDocs(
                     [ "/// This is a fist comment"
                       "/// This is a second comment"
@@ -86,34 +86,23 @@ let x = 12
     [<Test>]
     let ``Simple Let binding with multiline with a single attribute`` () =
         AnonymousModule() {
-            Let("x", "12").attributes([ "Literal" ])
+            Value("x", "12").attributes([ "Obsolete" ])
 
         }
         |> produces
             """
-[<Literal>]
-let x = 12
-
-"""
-
-    [<Test>]
-    let ``Produces a Literal constant`` () =
-        AnonymousModule() { Literal("x", "12").xmlDocs([ "/// This is a comment" ]) }
-        |> produces
-            """
-/// This is a comment
-[<Literal>]
+[<Obsolete>]
 let x = 12
 
 """
 
     [<Test>]
     let ``Simple Let binding with multiline with a multiple attributes`` () =
-        AnonymousModule() { Let("x", "12").attributes([ "Literal"; "Obsolete" ]) }
+        AnonymousModule() { Value("x", "12").attributes([ "EditorBrowsable"; "Obsolete" ]) }
         |> produces
             """
             
-[<Literal; Obsolete>]
+[<EditorBrowsable; Obsolete>]
 let x = 12
 
 """
@@ -172,7 +161,7 @@ let x = 12
 
     [<Test>]
     let ``Produces a top level mutable let binding`` () =
-        AnonymousModule() { Let("x", "12").isMutable() }
+        AnonymousModule() { Value("x", "12").isMutable() }
         |> produces
             """
         

--- a/src/Fabulous.AST.Tests/Namespaces/AnonymousModule.fs
+++ b/src/Fabulous.AST.Tests/Namespaces/AnonymousModule.fs
@@ -21,7 +21,7 @@ printfn "hello, world"
     [<Test>]
     let ``Produces Hello world with a let binding`` () =
         AnonymousModule() {
-            Let("x", "\"hello, world\"")
+            Value("x", "\"hello, world\"")
             Call("printfn", "\"%s\"", "x")
         }
         |> produces

--- a/src/Fabulous.AST.Tests/Namespaces/Module.fs
+++ b/src/Fabulous.AST.Tests/Namespaces/Module.fs
@@ -13,7 +13,7 @@ open type Ast
 module Module =
     [<Test>]
     let ``Produces a module with binding`` () =
-        Module("Fabulous.AST") { Let("x", "3") }
+        Module("Fabulous.AST") { Value("x", "3") }
         |> produces
             """
 module Fabulous.AST
@@ -41,7 +41,7 @@ module Fabulous.AST
                 Range.Zero
             )
         ) {
-            Let("x", "3")
+            Value("x", "3")
         }
         |> produces
             """
@@ -134,7 +134,7 @@ module Foo =
                 )
             }
 
-            NestedModule("Bar") { Let("x", "12") }
+            NestedModule("Bar") { Value("x", "12") }
         }
 
         |> produces

--- a/src/Fabulous.AST.Tests/Namespaces/Namespace.fs
+++ b/src/Fabulous.AST.Tests/Namespaces/Namespace.fs
@@ -13,7 +13,7 @@ open type Ast
 module Namespace =
     [<Test>]
     let ``Produces a namespace with binding`` () =
-        Namespace("Fabulous.AST") { Let("x", "3") }
+        Namespace("Fabulous.AST") { Value("x", "3") }
         |> produces
             """
 namespace Fabulous.AST
@@ -23,7 +23,7 @@ let x = 3
 
     [<Test>]
     let ``Produces a rec namespace with binding`` () =
-        Namespace("Fabulous.AST").isRecursive() { Let("x", "3") }
+        Namespace("Fabulous.AST").isRecursive() { Value("x", "3") }
         |> produces
             """
 namespace rec Fabulous.AST
@@ -52,7 +52,7 @@ namespace Fabulous.AST
                 Range.Zero
             )
         ) {
-            Let("x", "3")
+            Value("x", "3")
         }
         |> produces
             """

--- a/src/Fabulous.AST.Tests/Namespaces/NestedModule.fs
+++ b/src/Fabulous.AST.Tests/Namespaces/NestedModule.fs
@@ -14,7 +14,7 @@ module NestedModule =
 
     [<Test>]
     let ``Produces a NestedModule`` () =
-        AnonymousModule() { NestedModule("A") { Let("x", "12") } }
+        AnonymousModule() { NestedModule("A") { Value("x", "12") } }
 
         |> produces
             """
@@ -56,7 +56,7 @@ module A =
 
     [<Test>]
     let ``Produces a recursive NestedModule`` () =
-        AnonymousModule() { NestedModule("A").isRecursive() { Let("x", "12") } }
+        AnonymousModule() { NestedModule("A").isRecursive() { Value("x", "12") } }
 
         |> produces
             """
@@ -68,7 +68,7 @@ module rec A =
 
     [<Test>]
     let ``Produces a private NestedModule`` () =
-        AnonymousModule() { NestedModule("A").accessibility(AccessControl.Private) { Let("x", "12") } }
+        AnonymousModule() { NestedModule("A").accessibility(AccessControl.Private) { Value("x", "12") } }
         |> produces
             """
 
@@ -79,7 +79,7 @@ module private A =
 
     [<Test>]
     let ``Produces a internal NestedModule`` () =
-        AnonymousModule() { NestedModule("A").accessibility(AccessControl.Internal) { Let("x", "12") } }
+        AnonymousModule() { NestedModule("A").accessibility(AccessControl.Internal) { Value("x", "12") } }
         |> produces
             """
 

--- a/src/Fabulous.AST/Fabulous.AST.fsproj
+++ b/src/Fabulous.AST/Fabulous.AST.fsproj
@@ -41,13 +41,14 @@
         <Compile Include="Widgets\Match.fs" />
         <Compile Include="Widgets\MatchClause.fs" />
         <Compile Include="Widgets\Condition.fs" />
+        <Compile Include="Widgets\CommonYieldExtensions.fs" />
         <Compile Include="Widgets\Namespaces\AnonymousModule.fs" />
         <Compile Include="Widgets\Namespaces\Namespace.fs" />
         <Compile Include="Widgets\Namespaces\Module.fs" />
         <Compile Include="Widgets\Namespaces\NestedModule.fs" />
         <Compile Include="Widgets\OpenDirectives\Open.fs" />
         <Compile Include="Widgets\OpenDirectives\OpenType.fs" />
-        <Compile Include="Widgets\LetBindings\Let.fs" />
+        <Compile Include="Widgets\LetBindings\Value.fs" />
         <Compile Include="Widgets\LetBindings\Literal.fs" />
         <Compile Include="Widgets\LetBindings\Function.fs" />
         <Compile Include="Widgets\TypeDefinitions\UnionCase.fs" />
@@ -56,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Fantomas.Core"/>
+        <PackageReference Include="Fantomas.Core" />
     </ItemGroup>
 
 </Project>

--- a/src/Fabulous.AST/README.md
+++ b/src/Fabulous.AST/README.md
@@ -135,11 +135,11 @@ Fabulous.AST is a powerful tool for anyone who works with code and wants to auto
 
 #### Let bindings
 
-| Widget          | Description           | F# code                         |
-|-----------------|-----------------------|---------------------------------|
-| Value           | A let binding         | ```let x = 12```                |
-| Constant        | A constant definition | ```[<Literal>] let x = 12```    |
-| Function        | A function definition | ```let f x = x + 1```           |
+| Widget   | Description           | F# code                         |
+|----------|-----------------------|---------------------------------|
+| Value    | A let binding         | ```let x = 12```                |
+| Literal  | A literal definition  | ```[<Literal>] let x = 12```    |
+| Function | A function definition | ```let f x = x + 1```           |
 
 #### Type definitions
 

--- a/src/Fabulous.AST/Widgets/CommonYieldExtensions.fs
+++ b/src/Fabulous.AST/Widgets/CommonYieldExtensions.fs
@@ -1,0 +1,13 @@
+namespace Fabulous.AST
+
+open System.Runtime.CompilerServices
+open Fabulous.AST.StackAllocatedCollections
+open Fantomas.Core.SyntaxOak
+
+[<Extension>]
+type CommonYieldExtensions =
+    [<Extension>]
+    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, node: BindingNode) : CollectionContent =
+        let moduleDecl = ModuleDecl.TopLevelBinding node
+        let widget = Ast.EscapeHatch(moduleDecl).Compile()
+        { Widgets = MutStackArray1.One(widget) }

--- a/src/Fabulous.AST/Widgets/EscapeHatch.fs
+++ b/src/Fabulous.AST/Widgets/EscapeHatch.fs
@@ -20,11 +20,3 @@ module EscapeHatchBuilders =
 
         static member inline EscapeHatch(node: 'T) =
             WidgetBuilder<'T>(EscapeHatch.WidgetKey, EscapeHatch.Node.WithValue(node))
-
-[<Extension>]
-type EscapeHatchYieldExtensions =
-    [<Extension>]
-    static member inline Yield(_: CollectionBuilder<'parent, ModuleDecl>, node: BindingNode) : CollectionContent =
-        let moduleDecl = ModuleDecl.TopLevelBinding node
-        let widget = Ast.EscapeHatch(moduleDecl).Compile()
-        { Widgets = MutStackArray1.One(widget) }


### PR DESCRIPTION
As pointed out last time, we have a `Let` widget to define a value (`let x = 12`) but in the case of F#, `let` can mean several things: value, constant, and function.

So I renamed the `Let` widget to `Value` so it's clearer the specific use case this widget cover.

```fs
AnonymousModule() {
    Value("x", "12")
}
```