### PR TITLE
Add fsdocs and use build script.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "fantomas"
       ]
+    },
+    "fsdocs-tool": {
+      "version": "18.0.0",
+      "commands": [
+        "fsdocs"
+      ]
     }
   }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,19 +32,30 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
-      - name: Restore
-        run: dotnet restore ${SLN_FILE}
       - name: Build
-        run: dotnet build ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-restore
-      - name: Test
-        run: dotnet test ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --no-build
-      - name: Pack
-        run: |
-          dotnet pack ${SLN_FILE} -p:Version=${NIGHTLY_VERSION} -c ${CONFIG} --property PackageOutputPath=${PWD}/${NUPKG_FOLDER}
+        run: dotnet fsi build.fsx
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: Packages
           path: nupkgs/
+      - name: Upload docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: Docs
+          path: output/
       - name: Push
         run: dotnet nuget push "nupkgs/*" -s https://nuget.pkg.github.com/edgarfgp/index.json -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+          artifact_name: Docs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,13 +15,5 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.0.x
-    - name: Check code formatting
-      run: |
-        dotnet tool restore
-        dotnet fantomas --check src
-    - name: Restore
-      run: dotnet restore ${SLN_FILE}
-    - name: Build
-      run: dotnet build ${SLN_FILE} -c ${CONFIG} --no-restore
-    - name: Test
-      run: dotnet test ${SLN_FILE} -c ${CONFIG} --no-build
+    - name: CI
+      run: dotnet fsi build.fsx

--- a/.gitignore
+++ b/.gitignore
@@ -351,3 +351,8 @@ MigrationBackup/
 
 .idea/
 .DS_Store
+
+# FSharp.Formatting
+.fsdocs/
+tmp/
+output/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,11 @@
     <RepositoryUrl>https://github.com/edgarfgp/Fabulous.AST</RepositoryUrl>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+    <!-- Example ultra-simple styling and generation settings for FsDocs default template-->
+    <FsDocsLogoLink>https://github.com/edgarfgp/Fabulous.AST</FsDocsLogoLink>
+    <FsDocsLogoSource>https://github.com/edgarfgp.png</FsDocsLogoSource>
+    <FsDocsLicenseLink>https://github.com/edgarfgp/Fabulous.AST/blob/main/LICENSE</FsDocsLicenseLink>
+    <FsDocsReleaseNotesLink>https://github.com/edgarfgp/Fabulous.AST/blob/main/CHANGELOG.md</FsDocsReleaseNotesLink>
   </PropertyGroup>
 
   <!-- Shared NuGet Package info -->

--- a/build.fsx
+++ b/build.fsx
@@ -1,0 +1,51 @@
+#r "nuget: Fun.Build, 0.3.8"
+
+open System
+open System.IO
+open Fun.Build
+
+let (</>) a b = Path.Combine(a, b)
+let sln = __SOURCE_DIRECTORY__ </> "Fabulous.AST.sln"
+let config = "Release"
+let nupkgs = __SOURCE_DIRECTORY__ </> "nupkgs"
+
+let nightlyVersion =
+    Environment.GetEnvironmentVariable("NIGHTLY_VERSION")
+    |> Option.ofObj
+    |> Option.bind (fun nv -> if String.IsNullOrWhiteSpace(nv) then None else Some nv)
+
+let versionProperty =
+    match nightlyVersion with
+    | None -> String.Empty
+    | Some nv -> $"-p:Version=%s{nv}"
+
+pipeline "ci" {
+    description "Main pipeline used during pull requests"
+
+    stage "lint" {
+        run "dotnet tool restore"
+        run $"dotnet fantomas --check {__SOURCE_FILE__} src docs"
+    }
+
+    stage "build" {
+        run $"dotnet restore {sln}"
+        run $"dotnet build {sln} -c {config} --no-restore"
+        run $"dotnet test {sln} -c {config} --no-build"
+    }
+
+    stage "docs" {
+        run "dotnet publish src/Fabulous.AST -c Release"
+        run "dotnet fsdocs build --eval"
+    }
+
+    stage "pack" { run $"dotnet pack {sln} -c {config} -p:PackageOutputPath=\"%s{nupkgs}\" {versionProperty}" }
+
+    runIfOnlySpecified false
+}
+
+pipeline "docs" {
+    description "Run the documentation website"
+    stage "build" { run "dotnet publish src/Fabulous.AST -c Release" }
+    stage "watch" { run "dotnet fsdocs watch --eval --clean" }
+    runIfOnlySpecified true
+}

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -1,0 +1,113 @@
+﻿(**
+---
+title: Homepage
+category: docs
+index: 0
+---
+
+Welcome to the Fabulous.AST, an Abstract Syntax Tree (AST) Domain Specific Language (DSL) for F#.
+
+Fabulous.AST uses [Fantomas](https://fsprojects.github.io/fantomas/docs/end-users/GeneratingCode.html) to generate F# code from AST. This means that you can use Fabulous.AST to generate F# code that is formatted according to the Fantomas style guide. It's designed to provide a simple and expressive way to represent code as a tree of nodes. This makes it easier to manipulate and analyze code programmatically.
+
+Let's take a look at an AST example in Fantomas:
+*)
+
+#r "../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+#r "../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+
+open FSharp.Compiler.Text
+open Fantomas.Core
+open Fantomas.Core.SyntaxOak
+
+let implementationSyntaxTree =
+    Oak(
+        [],
+        [ ModuleOrNamespaceNode(
+              None,
+              [ BindingNode(
+                    None,
+                    None,
+                    MultipleTextsNode([ SingleTextNode("let", Range.Zero) ], Range.Zero),
+                    false,
+                    None,
+                    None,
+                    Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode("x", Range.Zero)) ], Range.Zero)),
+                    None,
+                    [],
+                    None,
+                    SingleTextNode("=", Range.Zero),
+                    Expr.Constant(Constant.FromText(SingleTextNode("12", Range.Zero))),
+                    Range.Zero
+                )
+                |> ModuleDecl.TopLevelBinding ],
+              Range.Zero
+          ) ],
+        Range.Zero
+    )
+
+CodeFormatter.FormatOakAsync(implementationSyntaxTree)
+|> Async.RunSynchronously
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+Now let's take a look at same example using Fabulous.AST:
+*)
+
+#r "../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+
+open Fabulous.AST
+open type Fabulous.AST.Ast
+
+let source = AnonymousModule() { Let("x", "12") }
+
+let oak = Tree.compile source
+CodeFormatter.FormatOakAsync(oak) |> Async.RunSynchronously |> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(** You can use an `Escape Hatch` to generate code that is not supported by Fabulous.AST yet by constructing the raw [Fantomas.SyntaxOak](https://fsprojects.github.io/fantomas/reference/fantomas-core-syntaxoak.html) node.
+For example, the following code: *)
+
+open type Fabulous.AST.Ast
+
+let topLevelBinding: ModuleDecl =
+    BindingNode(
+        xmlDoc = None,
+        attributes = None,
+        leadingKeyword = MultipleTextsNode([ SingleTextNode("let", Range.Zero) ], Range.Zero),
+        isMutable = false,
+        inlineNode = None,
+        // We cannot define private yet using Fabulous.AST
+        accessibility = Some(SingleTextNode("private", Range.Zero)),
+        functionName = Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode("x", Range.Zero)) ], Range.Zero)),
+        genericTypeParameters = None,
+        parameters = List.Empty,
+        returnType = None,
+        equals = SingleTextNode("=", Range.Zero),
+        expr = Expr.Constant(Constant.FromText(SingleTextNode("12", Range.Zero))),
+        range = Range.Zero
+    )
+    |> ModuleDecl.TopLevelBinding
+
+let sourceWithEscapeHatch =
+    AnonymousModule() {
+        Let("a", "11")
+        EscapeHatch(topLevelBinding)
+    }
+
+Tree.compile sourceWithEscapeHatch
+|> CodeFormatter.FormatOakAsync
+|> Async.RunSynchronously
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+(**
+Using Fabulous.AST, you can easily create and manipulate ASTs like this one using F# functions. For example, you can add new nodes to the AST, modify existing nodes, or traverse the AST to perform analysis or transformation tasks.
+
+Fabulous.AST is a powerful tool for anyone who works with code and wants to automate or streamline their development workflow. Whether you're a compiler writer, a code generator, or just someone who wants to write better code faster, Fabulous.AST can help you achieve your goals.
+*)


### PR DESCRIPTION
Initial setup of FSharp.Formatting for documentation.
I've included a small `build.fsx` script. This makes it easier to locally run what the CI will do.
Run `dotnet fsi build.fsx` to run the default pipeline. (Happens on CI)

Start the docs using `dotnet fsi build.fsx -p Docs` to launch the documentation locally.