### PR TITLE
Record and Union member support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fantomas.Core" Version="[6.0.0-alpha-010]" />
+    <PackageVersion Include="Fantomas.Core" Version="[6.0.0-beta-001]" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
@@ -74,3 +74,81 @@ type Colors =
 type Colors = { Red: int; Green: int; Blue: int }
 
 """
+
+    [<Test>]
+    let ``Produces a record with static member`` () =
+        let memberNode =
+            MemberDefn.Member(
+                BindingNode(
+                    None,
+                    None,
+                    MultipleTextsNode(
+                        [ SingleTextNode("static", Range.Zero); SingleTextNode("member", Range.Zero) ],
+                        Range.Zero
+                    ),
+                    false,
+                    None,
+                    None,
+                    Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode("A", Range.Zero)) ], Range.Zero)),
+                    None,
+                    List.Empty,
+                    None,
+                    SingleTextNode("=", Range.Zero),
+                    Expr.Constant(Constant.FromText(SingleTextNode("\"\"", Range.Zero))),
+                    Range.Zero
+                )
+            )
+
+        AnonymousModule() {
+            (Record("Colors") { Field("X", Type.FromString "string") }).members() { EscapeHatch(memberNode) }
+        }
+        |> produces
+            """
+
+type Colors =
+    { X: string }
+
+    static member A = ""
+
+"""
+
+    [<Test>]
+    let ``Produces a record with member`` () =
+        let memberNode =
+            MemberDefn.Member(
+                BindingNode(
+                    None,
+                    None,
+                    MultipleTextsNode([ SingleTextNode("member", Range.Zero) ], Range.Zero),
+                    false,
+                    None,
+                    None,
+                    Choice1Of2(
+                        IdentListNode(
+                            [ IdentifierOrDot.Ident(SingleTextNode("this", Range.Zero))
+                              IdentifierOrDot.Ident(SingleTextNode(".", Range.Zero))
+                              IdentifierOrDot.Ident(SingleTextNode("A", Range.Zero)) ],
+                            Range.Zero
+                        )
+                    ),
+                    None,
+                    List.Empty,
+                    None,
+                    SingleTextNode("=", Range.Zero),
+                    Expr.Constant(Constant.FromText(SingleTextNode("\"\"", Range.Zero))),
+                    Range.Zero
+                )
+            )
+
+        AnonymousModule() {
+            (Record("Colors") { Field("X", Type.FromString "string") }).members() { EscapeHatch(memberNode) }
+        }
+        |> produces
+            """
+
+type Colors =
+    { X: string }
+
+    member this.A = ""
+
+"""

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
@@ -103,3 +103,77 @@ type Colors =
     | Black
 
 """
+
+    [<Test>]
+    let ``Produces an union with static member`` () =
+        let memberNode =
+            MemberDefn.Member(
+                BindingNode(
+                    None,
+                    None,
+                    MultipleTextsNode(
+                        [ SingleTextNode("static", Range.Zero); SingleTextNode("member", Range.Zero) ],
+                        Range.Zero
+                    ),
+                    false,
+                    None,
+                    None,
+                    Choice1Of2(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode("A", Range.Zero)) ], Range.Zero)),
+                    None,
+                    List.Empty,
+                    None,
+                    SingleTextNode("=", Range.Zero),
+                    Expr.Constant(Constant.FromText(SingleTextNode("\"\"", Range.Zero))),
+                    Range.Zero
+                )
+            )
+
+        AnonymousModule() { (Union("Colors") { UnionCase("Red") }).members() { EscapeHatch(memberNode) } }
+        |> produces
+            """
+
+type Colors =
+    | Red
+
+    static member A = ""
+
+"""
+
+    [<Test>]
+    let ``Produces an union with member`` () =
+        let memberNode =
+            MemberDefn.Member(
+                BindingNode(
+                    None,
+                    None,
+                    MultipleTextsNode([ SingleTextNode("member", Range.Zero) ], Range.Zero),
+                    false,
+                    None,
+                    None,
+                    Choice1Of2(
+                        IdentListNode(
+                            [ IdentifierOrDot.Ident(SingleTextNode("this", Range.Zero))
+                              IdentifierOrDot.Ident(SingleTextNode(".", Range.Zero))
+                              IdentifierOrDot.Ident(SingleTextNode("A", Range.Zero)) ],
+                            Range.Zero
+                        )
+                    ),
+                    None,
+                    List.Empty,
+                    None,
+                    SingleTextNode("=", Range.Zero),
+                    Expr.Constant(Constant.FromText(SingleTextNode("\"\"", Range.Zero))),
+                    Range.Zero
+                )
+            )
+
+        AnonymousModule() { (Union("Colors") { UnionCase("Red") }).members() { EscapeHatch(memberNode) } }
+        |> produces
+            """
+
+type Colors =
+    | Red
+
+    member this.A = ""
+
+"""

--- a/src/Fabulous.AST/Core/Builders.fs
+++ b/src/Fabulous.AST/Core/Builders.fs
@@ -266,7 +266,7 @@ type CollectionBuilder<'marker, 'itemMarker> =
     end
 
 [<Struct>]
-type AttributeCollectionBuilder<'msg, 'marker, 'itemMarker> =
+type AttributeCollectionBuilder<'marker, 'itemMarker> =
     struct
         val Widget: WidgetBuilder<'marker>
         val Attr: WidgetCollectionAttributeDefinition

--- a/src/Fabulous.AST/Core/Helpers.fs
+++ b/src/Fabulous.AST/Core/Helpers.fs
@@ -56,8 +56,20 @@ module Helpers =
             let struct (count, elements) = value
             elements |> Array.take(int count) |> List.ofArray
 
+    let tryGetWidgetsFromWidgetCollection (widget: Widget) (def: WidgetCollectionAttributeDefinition) =
+        match tryGetWidgetCollectionValue widget def with
+        | ValueNone -> None
+        | ValueSome value ->
+            let struct (count, elements) = value
+            elements |> Array.take(int count) |> List.ofArray |> Some
+
     let getNodesFromWidgetCollection<'T> (widget: Widget) (def: WidgetCollectionAttributeDefinition) =
         getWidgetsFromWidgetCollection widget def |> List.map createValueForWidget<'T>
+
+    let tryGetNodesFromWidgetCollection<'T> (widget: Widget) (def: WidgetCollectionAttributeDefinition) =
+        match tryGetWidgetsFromWidgetCollection widget def with
+        | None -> None
+        | Some widgets -> Some(widgets |> List.map createValueForWidget<'T>)
 
     let createNodeFromBuilder (builder: WidgetBuilder<'T>) : 'U =
         builder.Compile() |> createValueForWidget<'U>

--- a/src/Fabulous.AST/Widgets/CommonYieldExtensions.fs
+++ b/src/Fabulous.AST/Widgets/CommonYieldExtensions.fs
@@ -16,3 +16,8 @@ type CommonYieldExtensions =
     static member inline Yield(_: CollectionBuilder<'parent, 'child>, x: 'child) : CollectionContent =
         let widget = Ast.EscapeHatch(x).Compile()
         { Widgets = MutStackArray1.One(widget) }
+
+    [<Extension>]
+    static member inline Yield(_: AttributeCollectionBuilder<'parent, 'child>, x: 'child) : CollectionContent =
+        let widget = Ast.EscapeHatch(x).Compile()
+        { Widgets = MutStackArray1.One(widget) }

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Union.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Union.fs
@@ -12,12 +12,21 @@ module Union =
 
     let Name = Attributes.defineWidget "SingleTextNode"
 
+    let Members = Attributes.defineWidgetCollection "Members"
+
     let WidgetKey =
         Widgets.register "Union" (fun widget ->
             let name = Helpers.getNodeFromWidget<SingleTextNode> widget Name
 
             let unionCaseNode =
                 Helpers.getNodesFromWidgetCollection<UnionCaseNode> widget UnionCaseNode
+
+            let members = Helpers.tryGetNodesFromWidgetCollection<MemberDefn> widget Members
+
+            let members =
+                match members with
+                | Some members -> members
+                | None -> []
 
             TypeDefnUnionNode(
                 TypeNameNode(
@@ -35,7 +44,7 @@ module Union =
                 ),
                 None,
                 unionCaseNode,
-                [],
+                members,
                 Range.Zero
             ))
 
@@ -54,6 +63,12 @@ module UnionBuilders =
 
         static member inline Union(name: string) =
             Ast.Union(SingleTextNode(name, Range.Zero))
+
+[<Extension>]
+type UnionModifiers =
+    [<Extension>]
+    static member inline members(this: WidgetBuilder<TypeDefnUnionNode>) =
+        AttributeCollectionBuilder<TypeDefnUnionNode, MemberDefn>(this, Union.Members)
 
 [<Extension>]
 type UnionYieldExtensions =


### PR DESCRIPTION
This PR adds support for adding any `MemberDefn` to `records and unions`
```fsharp
type MemberDefn =
| ImplicitInherit of InheritConstructor
| Inherit of MemberDefnInheritNode
| ValField of FieldNode
| Member of BindingNode
| ExternBinding of ExternBindingNode
| DoExpr of ExprSingleNode
| LetBinding of BindingListNode
| ExplicitCtor of MemberDefnExplicitCtorNode
| Interface of MemberDefnInterfaceNode
| AutoProperty of MemberDefnAutoPropertyNode
```