### PR TITLE
Support AppLongIdentAndSingleParenArg

### DIFF
--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
@@ -373,3 +373,21 @@ let mutable x = 12
 let inline x<'a> = 12
 
 """
+
+    [<Fact>]
+    let ``Produces let binding with AppLongIdentAndSingleParenArg expression``() =
+        Oak() {
+            AnonymousModule() {
+                Value("res", AppLongIdentAndSingleParenArg([ "conn"; "Open" ], ConstantExpr(ConstantUnit())))
+                Value("res2", AppLongIdentAndSingleParenArg([ "conn"; "Open" ], "()"))
+                Value("res3", AppLongIdentAndSingleParenArg("conn.Open", "()"))
+            }
+        }
+        |> produces
+            """
+
+let res = conn.Open()
+let res2 = conn.Open ()
+let res3 = conn.Open ()
+
+"""

--- a/src/Fabulous.AST/Fabulous.AST.fsproj
+++ b/src/Fabulous.AST/Fabulous.AST.fsproj
@@ -86,6 +86,7 @@
         <Compile Include="Widgets\Expressions\StructTuple.fs" />
         <Compile Include="Widgets\Expressions\ArrayOrList.fs" />
         <Compile Include="Widgets\Expressions\App.fs" />
+        <Compile Include="Widgets\Expressions\AppLongIdentAndSingleParenArg.fs" />
         <Compile Include="Widgets\Expressions\MatchClause.fs" />
         <Compile Include="Widgets\Expressions\Match.fs" />
         <Compile Include="Widgets\Expressions\InfixApp.fs" />

--- a/src/Fabulous.AST/Widgets/Expressions/AppLongIdentAndSingleParenArg.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/AppLongIdentAndSingleParenArg.fs
@@ -1,0 +1,96 @@
+namespace Fabulous.AST
+
+open Fabulous.AST.StackAllocatedCollections.StackList
+open Fantomas.FCS.Text
+open Fantomas.Core.SyntaxOak
+
+open type Fabulous.AST.Ast
+
+module AppLongIdentAndSingleParenArg =
+    let ExprVal = Attributes.defineScalar<StringOrWidget<Expr>> "Name"
+    let FunctionName = Attributes.defineScalar<string list> "FunctionName"
+
+    let WidgetKey =
+        Widgets.register "AppLongIdentAndSingleParenArg" (fun widget ->
+            let expr = Widgets.getScalarValue widget ExprVal
+
+            let functionName =
+                Widgets.getScalarValue widget FunctionName
+                |> List.map(SingleTextNode.Create)
+                |> List.intersperse(SingleTextNode.Create ".")
+
+            let expr =
+                match expr with
+                | StringOrWidget.StringExpr value ->
+                    Expr.Constant(
+                        Constant.FromText(SingleTextNode.Create(StringParsing.normalizeIdentifierQuotes(value)))
+                    )
+                | StringOrWidget.WidgetExpr expr -> expr
+
+            Expr.AppLongIdentAndSingleParenArg(
+                ExprAppLongIdentAndSingleParenArgNode(
+                    IdentListNode(
+                        [ for name in functionName do
+                              IdentifierOrDot.Ident(name) ],
+                        Range.Zero
+                    ),
+                    expr,
+                    Range.Zero
+                )
+            ))
+
+[<AutoOpen>]
+module AppLongIdentAndSingleParenArgBuilders =
+    type Ast with
+
+        static member AppLongIdentAndSingleParenArg(name: string list, expr: WidgetBuilder<Expr>) =
+            WidgetBuilder<Expr>(
+                AppLongIdentAndSingleParenArg.WidgetKey,
+                AttributesBundle(
+                    StackList.two(
+                        AppLongIdentAndSingleParenArg.FunctionName.WithValue(name),
+                        AppLongIdentAndSingleParenArg.ExprVal.WithValue(StringOrWidget.WidgetExpr(Gen.mkOak expr))
+                    ),
+                    Array.empty,
+                    Array.empty
+                )
+            )
+
+        static member AppLongIdentAndSingleParenArg(name: string, expr: WidgetBuilder<Expr>) =
+            WidgetBuilder<Expr>(
+                AppLongIdentAndSingleParenArg.WidgetKey,
+                AttributesBundle(
+                    StackList.two(
+                        AppLongIdentAndSingleParenArg.FunctionName.WithValue([ name ]),
+                        AppLongIdentAndSingleParenArg.ExprVal.WithValue(StringOrWidget.WidgetExpr(Gen.mkOak expr))
+                    ),
+                    Array.empty,
+                    Array.empty
+                )
+            )
+
+        static member AppLongIdentAndSingleParenArg(name: string list, expr: string) =
+            WidgetBuilder<Expr>(
+                AppLongIdentAndSingleParenArg.WidgetKey,
+                AttributesBundle(
+                    StackList.two(
+                        AppLongIdentAndSingleParenArg.FunctionName.WithValue(name),
+                        AppLongIdentAndSingleParenArg.ExprVal.WithValue(StringOrWidget.StringExpr(Unquoted expr))
+                    ),
+                    Array.empty,
+                    Array.empty
+                )
+            )
+
+        static member AppLongIdentAndSingleParenArg(name: string, expr: string) =
+            WidgetBuilder<Expr>(
+                AppLongIdentAndSingleParenArg.WidgetKey,
+                AttributesBundle(
+                    StackList.two(
+                        AppLongIdentAndSingleParenArg.FunctionName.WithValue([ name ]),
+                        AppLongIdentAndSingleParenArg.ExprVal.WithValue(StringOrWidget.StringExpr(Unquoted expr))
+                    ),
+                    Array.empty,
+                    Array.empty
+                )
+            )


### PR DESCRIPTION
Based on the [Oak AST](https://fsprojects.github.io/fantomas-tools/#/oak?data=N4KABGBEDGD2AmBTSAuKAbRAXMAnRAzmALxhwB25AdAPIAOi5AFAJSQA04USAZgJblCqKBy6Q%2BBAGIE%2BwngEN0BRJwjiCAcVzy6ACwBqfRAHc5i5SAC%2BQA) generated this we can add support for this

```fsharp 
    [<Fact>]
    let ``Produces let binding with AppLongIdentAndSingleParenArg expression``() =
        Oak() {
            AnonymousModule() {
                Value("res", AppLongIdentAndSingleParenArg([ "conn"; "Open" ], ConstantExpr(ConstantUnit())))
                Value("res2", AppLongIdentAndSingleParenArg([ "conn"; "Open" ], "()"))
                Value("res3", AppLongIdentAndSingleParenArg("conn.Open", "()"))
            }
        }
        |> produces
            """

let res = conn.Open()
let res2 = conn.Open ()
let res3 = conn.Open ()

"""
```