### PR TITLE
Finish abstract members

### DIFF
--- a/docs/widgets/MemberDefinitions.fsx
+++ b/docs/widgets/MemberDefinitions.fsx
@@ -70,7 +70,7 @@ Oak() {
                 Setter(ParenPat(NamedPat("value")), LongIdentSetExpr("_age", "value"))
             )
 
-            AbstractSlot("GetValue", [ Unit() ], String())
+            AbstractMember("GetValue", [ Unit() ], String())
 
             Default("this.GetValue", UnitPat(), ConstantExpr(String("Hello World")))
 

--- a/docs/widgets/TypeDefinitions.fsx
+++ b/docs/widgets/TypeDefinitions.fsx
@@ -143,8 +143,8 @@ Oak() {
         Augmentation("Variant") { Method("x.Print", UnitPat(), AppExpr("Variant.print", "x")) }
 
         TypeDefn("IFoo") {
-            AbstractSlot("Area", Float(), true)
-            AbstractSlot("Area1", LongIdent "float", true)
+            AbstractMember("Area", Float(), true)
+            AbstractMember("Area1", LongIdent "float", true)
         }
 
         TypeDefn("X") {

--- a/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
@@ -9,40 +9,124 @@ open type Ast
 module AbstractMembers =
 
     [<Fact>]
-    let ``Produces a classes with a abstract members``() =
+    let ``Produces a classes with a abstracts``() =
         Oak() {
             AnonymousModule() {
                 TypeDefn("Meh") {
-                    AbstractSlot("Area", Float(), true)
-                    AbstractSlot("Area1", LongIdent "float", true)
+                    Abstract("Area", Float(), true)
+                    Abstract("Area1", LongIdent "float", true)
 
-                    AbstractSlot("Area2", Float(), hasSetter = true)
-                    AbstractSlot("Area3", LongIdent "float", hasSetter = true)
+                    Abstract("Area2", Float(), hasSetter = true)
+                    Abstract("Area3", LongIdent "float", hasSetter = true)
 
-                    AbstractSlot("Area4", Float(), true, true)
-                    AbstractSlot("Area5", LongIdent "float", true, true)
+                    Abstract("Area4", Float(), true, true)
+                    Abstract("Area5", LongIdent "float", true, true)
 
-                    AbstractSlot("Pi", Float())
-                    AbstractSlot("Pi2", LongIdent "float")
+                    Abstract("Pi", Float())
+                    Abstract("Pi2", LongIdent "float")
 
-                    AbstractSlot("Add", [ LongIdent "int"; LongIdent "int" ], LongIdent "int", true)
-                    AbstractSlot("Add2", [ Int(); Int() ], Int(), true)
+                    Abstract("Add", [ LongIdent "int"; LongIdent "int" ], LongIdent "int", true)
+                    Abstract("Add2", [ Int(); Int() ], Int(), true)
 
-                    AbstractSlot("Add3", [ (Some "a", Int()); (Some "b", Int()) ], Int(), true)
+                    Abstract("Add3", [ (Some "a", Int()); (Some "b", Int()) ], Int(), true)
 
-                    AbstractSlot(
+                    Abstract(
                         "Add4",
                         [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ],
                         LongIdent "int",
                         true
                     )
 
-                    AbstractSlot("Add5", [ LongIdent "int"; LongIdent "int" ], LongIdent "int")
-                    AbstractSlot("Add6", [ Int(); Int() ], Int())
+                    Abstract("Add5", [ LongIdent "int"; LongIdent "int" ], LongIdent "int")
+                    Abstract("Add6", [ Int(); Int() ], Int())
 
-                    AbstractSlot("Add7", [ (Some "a", Int()); (Some "b", Int()) ], Int())
+                    Abstract("Add7", [ (Some "a", Int()); (Some "b", Int()) ], Int())
 
-                    AbstractSlot("Add8", [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ], LongIdent "int")
+                    Abstract("Add8", [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ], LongIdent "int")
+
+                }
+            }
+        }
+        |> produces
+            """
+type Meh =
+    abstract Area: float with get
+    abstract Area1: float with get
+    abstract Area2: float with set
+    abstract Area3: float with set
+    abstract Area4: float with get, set
+    abstract Area5: float with get, set
+    abstract Pi: float
+    abstract Pi2: float
+    abstract Add: int * int -> int
+    abstract Add2: int * int -> int
+    abstract Add3: a: int * b: int -> int
+    abstract Add4: a: int * b: int -> int
+    abstract Add5: int -> int -> int
+    abstract Add6: int -> int -> int
+    abstract Add7: a: int -> b: int -> int
+    abstract Add8: a: int -> b: int -> int
+"""
+
+    [<Fact>]
+    let ``Produces a abstract members with type params``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Meh") {
+                    Abstract("Area", [ LongIdent "'a" ], Float()).typeParams(PostfixList([ "'a" ]))
+
+                    AbstractMember("Area1", [ LongIdent "'b" ], Float())
+                        .typeParams(PostfixList([ "'b" ]))
+
+                }
+            }
+        }
+        |> produces
+            """
+type Meh =
+    abstract Area<'a> : 'a -> float
+    abstract member Area1<'b> : 'b -> float
+"""
+
+    [<Fact>]
+    let ``Produces a classes with a abstract members``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Meh") {
+                    AbstractMember("Area", Float(), true)
+                    AbstractMember("Area1", LongIdent "float", true)
+
+                    AbstractMember("Area2", Float(), hasSetter = true)
+                    AbstractMember("Area3", LongIdent "float", hasSetter = true)
+
+                    AbstractMember("Area4", Float(), true, true)
+                    AbstractMember("Area5", LongIdent "float", true, true)
+
+                    AbstractMember("Pi", Float())
+                    AbstractMember("Pi2", LongIdent "float")
+
+                    AbstractMember("Add", [ LongIdent "int"; LongIdent "int" ], LongIdent "int", true)
+                    AbstractMember("Add2", [ Int(); Int() ], Int(), true)
+
+                    AbstractMember("Add3", [ (Some "a", Int()); (Some "b", Int()) ], Int(), true)
+
+                    AbstractMember(
+                        "Add4",
+                        [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ],
+                        LongIdent "int",
+                        true
+                    )
+
+                    AbstractMember("Add5", [ LongIdent "int"; LongIdent "int" ], LongIdent "int")
+                    AbstractMember("Add6", [ Int(); Int() ], Int())
+
+                    AbstractMember("Add7", [ (Some "a", Int()); (Some "b", Int()) ], Int())
+
+                    AbstractMember(
+                        "Add8",
+                        [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ],
+                        LongIdent "int"
+                    )
 
                 }
             }
@@ -74,36 +158,40 @@ type Meh =
         Oak() {
             AnonymousModule() {
                 TypeDefn("Meh") {
-                    AbstractSlot("Area", Float(), true)
-                    AbstractSlot("Area1", LongIdent "float", true)
+                    AbstractMember("Area", Float(), true)
+                    AbstractMember("Area1", LongIdent "float", true)
 
-                    AbstractSlot("Area2", Float(), hasSetter = true)
-                    AbstractSlot("Area3", LongIdent "float", hasSetter = true)
+                    AbstractMember("Area2", Float(), hasSetter = true)
+                    AbstractMember("Area3", LongIdent "float", hasSetter = true)
 
-                    AbstractSlot("Area4", Float(), true, true)
-                    AbstractSlot("Area5", LongIdent "float", true, true)
+                    AbstractMember("Area4", Float(), true, true)
+                    AbstractMember("Area5", LongIdent "float", true, true)
 
-                    AbstractSlot("Pi", Float())
-                    AbstractSlot("Pi2", LongIdent "float")
+                    AbstractMember("Pi", Float())
+                    AbstractMember("Pi2", LongIdent "float")
 
-                    AbstractSlot("Add", [ LongIdent "int"; LongIdent "int" ], LongIdent "int", true)
-                    AbstractSlot("Add2", [ Int(); Int() ], Int(), true)
+                    AbstractMember("Add", [ LongIdent "int"; LongIdent "int" ], LongIdent "int", true)
+                    AbstractMember("Add2", [ Int(); Int() ], Int(), true)
 
-                    AbstractSlot("Add3", [ (Some "a", Int()); (Some "b", Int()) ], Int(), true)
+                    AbstractMember("Add3", [ (Some "a", Int()); (Some "b", Int()) ], Int(), true)
 
-                    AbstractSlot(
+                    AbstractMember(
                         "Add4",
                         [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ],
                         LongIdent "int",
                         true
                     )
 
-                    AbstractSlot("Add5", [ LongIdent "int"; LongIdent "int" ], LongIdent "int")
-                    AbstractSlot("Add6", [ Int(); Int() ], Int())
+                    AbstractMember("Add5", [ LongIdent "int"; LongIdent "int" ], LongIdent "int")
+                    AbstractMember("Add6", [ Int(); Int() ], Int())
 
-                    AbstractSlot("Add7", [ (Some "a", Int()); (Some "b", Int()) ], Int())
+                    AbstractMember("Add7", [ (Some "a", Int()); (Some "b", Int()) ], Int())
 
-                    AbstractSlot("Add8", [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ], LongIdent "int")
+                    AbstractMember(
+                        "Add8",
+                        [ (Some "a", LongIdent "int"); (Some "b", LongIdent "int") ],
+                        LongIdent "int"
+                    )
 
                 }
                 |> _.typeParams(PostfixList([ "'other"; "'another" ]))
@@ -138,20 +226,20 @@ type Meh<'other, 'another> =
                 TypeDefn("IMeh") {
                     Inherit("IFoo")
 
-                    AbstractSlot("ClientInfo1", "{| Name: string; Version: string option |}")
-                    AbstractSlot("ClientInfo2", AnonRecord([ ("Name", "string"); ("Version", "string option") ]))
+                    AbstractMember("ClientInfo1", "{| Name: string; Version: string option |}")
+                    AbstractMember("ClientInfo2", AnonRecord([ ("Name", "string"); ("Version", "string option") ]))
 
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo3",
                         AnonRecord([ ("Name", String()); ("Version", LongIdent("string option")) ])
                     )
 
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo4",
                         AnonRecord([ ("Name", String()); ("Version", AppPostfix(String(), "option")) ])
                     )
 
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo4",
                         AppPostfix(
                             AnonRecord([ ("Name", String()); ("Version", AppPostfix(String(), "option")) ]),
@@ -189,12 +277,12 @@ type IMeh =
         Oak() {
             AnonymousModule() {
                 TypeDefn("IMeh") {
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo1",
                         AnonRecord([ ("Name", String()); ("Version", OptionPostfix(String())) ])
                     )
 
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo2",
                         OptionPostfix(AnonRecord([ ("Name", String()); ("Version", OptionPostfix(String())) ]))
                     )
@@ -218,7 +306,7 @@ type IMeh =
         Oak() {
             AnonymousModule() {
                 TypeDefn("IMeh") {
-                    AbstractSlot(
+                    AbstractMember(
                         "ClientInfo1",
                         Array(
                             AppPrefix(

--- a/src/Fabulous.AST.Tests/MemberDefinitions/Interface.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/Interface.fs
@@ -12,8 +12,8 @@ module InterfaceMembers =
     let ``Produces a record with TypeParams and interface member``() =
         Oak() {
             AnonymousModule() {
-                TypeDefn("IMyInterface") { AbstractSlot("GetValue", [ Unit() ], String()) }
-                TypeDefn("IMyInterface2") { AbstractSlot("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface") { AbstractMember("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface2") { AbstractMember("GetValue", [ Unit() ], String()) }
 
                 (Record("Colors") {
                     Field("Green", LongIdent("string"))
@@ -59,7 +59,7 @@ type Colors<'other> =
             AnonymousModule() {
                 TypeDefn("IMyInterface") {
                     let parameters = [ Unit() ]
-                    AbstractSlot("GetValue", parameters, String())
+                    AbstractMember("GetValue", parameters, String())
                 }
 
                 (Record("MyRecord") {
@@ -92,7 +92,7 @@ type MyRecord =
         Oak() {
 
             AnonymousModule() {
-                TypeDefn("Meh") { AbstractSlot("Name", String()) }
+                TypeDefn("Meh") { AbstractMember("Name", String()) }
 
                 Class("Person") {
                     InterfaceMember(LongIdent "Meh") {
@@ -116,11 +116,11 @@ type Person() =
         Oak() {
 
             AnonymousModule() {
-                TypeDefn("IFoo") { AbstractSlot("Name", String()) }
+                TypeDefn("IFoo") { AbstractMember("Name", String()) }
 
                 InterfaceEnd("IFoo2")
 
-                TypeDefn("IFoo3") { AbstractSlot("Name", String()) }
+                TypeDefn("IFoo3") { AbstractMember("Name", String()) }
 
                 InterfaceEnd("IFoo4")
 

--- a/src/Fabulous.AST.Tests/MemberDefinitions/MemberDefn.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/MemberDefn.fs
@@ -12,9 +12,9 @@ module MemberDefn =
     let ``yield! multiple MemberDefns``() =
         Oak() {
             AnonymousModule() {
-                TypeDefn("IMyInterface") { AbstractSlot("GetValue", [ Unit() ], String()) }
-                TypeDefn("IMyInterface1") { AbstractSlot("GetValue", [ Unit() ], String()) }
-                TypeDefn("IMyInterface2") { AbstractSlot("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface") { AbstractMember("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface1") { AbstractMember("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface2") { AbstractMember("GetValue", [ Unit() ], String()) }
 
                 (Record("Colors") {
                     Field("Green", LongIdent("string"))

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Function.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Function.fs
@@ -303,7 +303,7 @@ let internal z i = ()
         Oak() {
             AnonymousModule() {
                 Class("Person") {
-                    AbstractSlot("GetValue", [ Unit() ], String())
+                    AbstractMember("GetValue", [ Unit() ], String())
                     Default("this.GetValue", UnitPat(), ConstantExpr(String("")))
                 }
             }

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Interface.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Interface.fs
@@ -11,9 +11,9 @@ module Interface =
     let ``Produces an interface abstract method``() =
         Oak() {
             AnonymousModule() {
-                TypeDefn("INumericFSharp") { AbstractSlot("Add", [ Int(); Int() ], Int()) }
+                TypeDefn("INumericFSharp") { AbstractMember("Add", [ Int(); Int() ], Int()) }
 
-                TypeDefn("INumericDotNet") { AbstractSlot("Add", [ Int(); Int() ], Int(), true) }
+                TypeDefn("INumericDotNet") { AbstractMember("Add", [ Int(); Int() ], Int(), true) }
             }
         }
         |> produces
@@ -34,9 +34,9 @@ module GenericInterface =
             AnonymousModule() {
                 TypeDefn("MyInterface") {
                     let parameters = [ Int(); Int(); String() ]
-                    AbstractSlot("Add", parameters, Int())
-                    AbstractSlot("Pi", Float())
-                    AbstractSlot("Area", Float(), true, true)
+                    AbstractMember("Add", parameters, Int())
+                    AbstractMember("Pi", Float())
+                    AbstractMember("Area", Float(), true, true)
                 }
                 |> _.typeParams(PostfixList([ "'other"; "'another" ]))
 

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
@@ -78,7 +78,7 @@ type Option<'a> =
 
                 TypeDefn("IMyInterface") {
                     let parameters = [ Unit() ]
-                    AbstractSlot("GetValue", parameters, String())
+                    AbstractMember("GetValue", parameters, String())
                 }
 
                 (Union("Colors") {
@@ -238,7 +238,7 @@ type Colors<'other> =
     let ``Produces an union with TypeParams and interface member``() =
         Oak() {
             AnonymousModule() {
-                TypeDefn("IMyInterface") { AbstractSlot("GetValue", [ Unit() ], String()) }
+                TypeDefn("IMyInterface") { AbstractMember("GetValue", [ Unit() ], String()) }
 
                 (Union("Colors") {
                     UnionCase("Red", [ Field("a", String()); Field(LongIdent("'other")) ])


### PR DESCRIPTION
This pull request includes significant changes to the `Fabulous.AST.Tests` and `Fabulous.AST` projects, primarily focused on renaming `AbstractSlot` to `AbstractMember` across various files and updating the corresponding tests. The changes also introduce new attributes and modify existing ones to better align with the new naming convention.

### Refactoring and Renaming:

* [`src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs`](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eR11-R129): Renamed `AbstractSlot` to `AbstractMember` in multiple test cases to reflect the new naming convention. [[1]](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eR11-R129) [[2]](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eL77-R194) [[3]](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eL141-R242) [[4]](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eL192-R285) [[5]](diffhunk://#diff-132582624342607a5218fd22b45f6fdd36e17e51f20e80e5e2caf68d19a7187eL221-R309)
* [`src/Fabulous.AST.Tests/MemberDefinitions/Interface.fs`](diffhunk://#diff-9020b81b80374283782e10e1c1de74253a890eda7513110d8949bcee7a70d61aL15-R16): Updated interface member definitions to use `AbstractMember` instead of `AbstractSlot`. [[1]](diffhunk://#diff-9020b81b80374283782e10e1c1de74253a890eda7513110d8949bcee7a70d61aL15-R16) [[2]](diffhunk://#diff-9020b81b80374283782e10e1c1de74253a890eda7513110d8949bcee7a70d61aL62-R62) [[3]](diffhunk://#diff-9020b81b80374283782e10e1c1de74253a890eda7513110d8949bcee7a70d61aL95-R95) [[4]](diffhunk://#diff-9020b81b80374283782e10e1c1de74253a890eda7513110d8949bcee7a70d61aL119-R123)
* [`src/Fabulous.AST.Tests/MemberDefinitions/MemberDefn.fs`](diffhunk://#diff-b4e743dc9b5b75d78a0933ab52286edcc50dfad00d6b709c3cde2b2b18bda86aL15-R17): Changed `AbstractSlot` to `AbstractMember` in the `MemberDefn` module tests.
* [`src/Fabulous.AST.Tests/TypeDefinitions/Interface.fs`](diffhunk://#diff-c02557404fd8b3011ff8c478ea42a766e1e7c6bf8be524b174116a7a1c016d1cL14-R16): Refactored interface type definitions to use `AbstractMember`. [[1]](diffhunk://#diff-c02557404fd8b3011ff8c478ea42a766e1e7c6bf8be524b174116a7a1c016d1cL14-R16) [[2]](diffhunk://#diff-c02557404fd8b3011ff8c478ea42a766e1e7c6bf8be524b174116a7a1c016d1cL37-R39)
* [`src/Fabulous.AST.Tests/TypeDefinitions/Union.fs`](diffhunk://#diff-071f6c4db4bada67cf5302bcb6871ba452de5dae98ea6cfb9f2fd2071c28fcf9L81-R81): Updated union type definitions to use `AbstractMember` instead of `AbstractSlot`. [[1]](diffhunk://#diff-071f6c4db4bada67cf5302bcb6871ba452de5dae98ea6cfb9f2fd2071c28fcf9L81-R81) [[2]](diffhunk://#diff-071f6c4db4bada67cf5302bcb6871ba452de5dae98ea6cfb9f2fd2071c28fcf9L241-R241)

### New Attributes and Modifications:

* [`src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs`](diffhunk://#diff-9dfd41bd4b1eb3ebc29c149aa8499459f34281821bd328a0a1ac583436ea886eR19-R33): Added new attributes `HasMemberKeyword` and `TypeParams` to the `AbstractMember` widget. Modified the widget registration to include these new attributes and updated the `MemberDefnAbstractSlotNode` to handle them. [[1]](diffhunk://#diff-9dfd41bd4b1eb3ebc29c149aa8499459f34281821bd328a0a1ac583436ea886eR19-R33) [[2]](diffhunk://#diff-9dfd41bd4b1eb3ebc29c149aa8499459f34281821bd328a0a1ac583436ea886eR108-R125) [[3]](diffhunk://#diff-9dfd41bd4b1eb3ebc29c149aa8499459f34281821bd328a0a1ac583436ea886eL114-R134)

These changes ensure consistency in naming conventions and enhance the functionality of the `AbstractMember` widget by introducing new attributes and updating tests accordingly.