### PR TITLE
Avoid using `NormalizeIdentifierBackticks` when generating `IdentifierOrDot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 _No unreleased changes_
 
-## [1.2.0] - 2025-03-03
+## [1.2.0] - 2025-03-05
 ### Fixed
-- Avoid using `NormalizeIdentifierBackticks` when generating `IdentifierOrDot` by @edgarfgp in https://github.com/edgarfgp/Fabulous.AST/pull/128
+- Avoid using `NormalizeIdentifierBackticks` when generating `IdentifierOrDot` by @edgarfgp in https://github.com/edgarfgp/Fabulous.AST/pull/137
 
 ## [1.1.0] - 2025-01-12
 
@@ -271,7 +271,8 @@ _No unreleased changes_
 
 - Initial release
 
-[unreleased]: https://github.com/edgarfgp/Fabulous.AST/compare/1.1.0...HEAD
+[unreleased]: https://github.com/edgarfgp/Fabulous.AST/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/edgarfgp/Fabulous.AST/releases/tag/1.2.0
 [1.1.0]: https://github.com/edgarfgp/Fabulous.AST/releases/tag/1.1.0
 [1.0.0]: https://github.com/edgarfgp/Fabulous.AST/releases/tag/1.0.0
 [1.0.0-pre17]: https://github.com/edgarfgp/Fabulous.AST/releases/tag/1.0.0-pre17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 _No unreleased changes_
 
+## [1.2.0] - 2025-03-03
+### Fixed
+- Avoid using `NormalizeIdentifierBackticks` when generating `IdentifierOrDot` by @edgarfgp in https://github.com/edgarfgp/Fabulous.AST/pull/128
+
 ## [1.1.0] - 2025-01-12
 
 ### Changed

--- a/src/Fabulous.AST.Tests/Expressions/Match.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Match.fs
@@ -39,3 +39,28 @@ match [ 1; 2 ] with
 match [ 1; 2 ] with
 | a -> 3
 """
+
+    [<Fact>]
+    let ``Match expression with multiple clauses``() =
+        Oak() {
+            AnonymousModule() {
+                MatchExpr(
+                    "value",
+                    [ MatchClauseExpr(
+                          LongIdentPat("Member.C.C7b7df1dc", "arg1"),
+                          ConstantExpr("failwith \"Not implemented\"")
+                      )
+
+                      MatchClauseExpr(
+                          LongIdentPat("Member.C.C7b7df1dc", ParenPat(TuplePat([ "arg1"; "arg2" ]))),
+                          ConstantExpr("failwith \"Not implemented\"")
+                      ) ]
+                )
+            }
+        }
+        |> produces
+            """
+match value with
+| Member.C.C7b7df1dc arg1 -> failwith "Not implemented"
+| Member.C.C7b7df1dc(arg1, arg2) -> failwith "Not implemented"
+"""

--- a/src/Fabulous.AST/Widgets/Patterns/LongIdent.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/LongIdent.fs
@@ -31,14 +31,10 @@ module LongIdentPattern =
                     |> Some
                 | ValueNone -> None
 
-            let identifier = Widgets.tryGetScalarValue widget Identifiers
-
             let identifier =
-                match identifier with
-                | ValueSome value ->
-                    [ let value = PrettyNaming.NormalizeIdentifierBackticks value
-                      IdentifierOrDot.Ident(SingleTextNode.Create(value)) ]
-                | ValueNone -> []
+                Widgets.tryGetScalarValue widget Identifiers
+                |> ValueOption.map(fun value -> [ IdentifierOrDot.Ident(SingleTextNode.Create(value)) ])
+                |> ValueOption.defaultValue []
 
             Pattern.LongIdent(
                 PatLongIdentNode(None, IdentListNode(identifier, Range.Zero), typeParams, items, Range.Zero)


### PR DESCRIPTION
Fix #136 

```fsharp
MatchExpr(
    "value",
    [ MatchClauseExpr(
          LongIdentPat("Member.C.C7b7df1dc", "arg1"),
          ConstantExpr("failwith \"Not implemented\"")
      )

      MatchClauseExpr(
          LongIdentPat("Member.C.C7b7df1dc", ParenPat(TuplePat([ "arg1"; "arg2" ]))),
          ConstantExpr("failwith \"Not implemented\"")
      ) ]
)
```

generates

```fsharp
match value with
| ``Member.C.C7b7df1dc arg1`` -> failwith "Not implemented"
| ``Member.C.C7b7df1dc`` (arg1, arg2) -> failwith "Not implemented"
```

But what we want is

```fsharp
match value with
| Member.C.C7b7df1dc arg1 -> failwith "Not implemented"
| Member.C.C7b7df1dc(arg1, arg2) -> failwith "Not implemented"
```