### PR TITLE
add PipeRightExpr and PipeLeftExpr widgets

### DIFF
--- a/src/Fabulous.AST.Tests/Expressions/InfixApp.fs
+++ b/src/Fabulous.AST.Tests/Expressions/InfixApp.fs
@@ -10,15 +10,32 @@ open type Ast
 module InfixApp =
 
     [<Fact>]
-    let ``let value with a InfixApp expression``() =
+    let ``InfixApp expressions``() =
         Oak() {
             AnonymousModule() {
                 InfixAppExpr(ConstantExpr(Constant("a")), "|>", ConstantExpr(Constant("b")))
+
+                PipeRightExpr(ConstantExpr(Constant("a")), ConstantExpr(Constant("b")))
+
+                PipeRightExpr(Constant("a"), Constant("b"))
+
+                PipeRightExpr("a", "b")
+
+                PipeLeftExpr(ConstantExpr(Constant("a")), ConstantExpr(Constant("b")))
+
+                PipeLeftExpr(Constant("a"), Constant("b"))
+
+                PipeLeftExpr("a", "b")
 
             }
         }
         |> produces
             """
-
 a |> b
+a |> b
+a |> b
+a |> b
+a <| b
+a <| b
+a <| b
 """

--- a/src/Fabulous.AST/Widgets/Expressions/InfixApp.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/InfixApp.fs
@@ -11,7 +11,7 @@ module InfixApp =
     let RightHandSide = Attributes.defineWidget "RightHandSide"
 
     let WidgetKey =
-        Widgets.register "Condition" (fun widget ->
+        Widgets.register "InfixApp" (fun widget ->
             let lhs = Widgets.getNodeFromWidget widget LeftHandSide
             let operator = Widgets.getScalarValue widget Operator
             let rhs = Widgets.getNodeFromWidget widget RightHandSide
@@ -45,3 +45,45 @@ module InfixAppBuilders =
 
         static member InfixAppExpr(lhs: string, operator: string, rhs: string) =
             Ast.InfixAppExpr(lhs, operator, Ast.Constant(rhs))
+
+        static member InfixAppExpr(lhs: WidgetBuilder<Expr>, operator: string, rhs: WidgetBuilder<Constant>) =
+            Ast.InfixAppExpr(lhs, operator, Ast.ConstantExpr(rhs))
+
+        static member InfixAppExpr(lhs: WidgetBuilder<Constant>, operator: string, rhs: string) =
+            Ast.InfixAppExpr(Ast.ConstantExpr(lhs), operator, Ast.Constant(rhs))
+
+        static member PipeRightExpr(lhs: WidgetBuilder<Expr>, rhs: WidgetBuilder<Expr>) =
+            Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: WidgetBuilder<Constant>, rhs: WidgetBuilder<Expr>) =
+            Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: string, rhs: WidgetBuilder<Expr>) = Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: WidgetBuilder<Expr>, rhs: WidgetBuilder<Constant>) =
+            Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: WidgetBuilder<Constant>, rhs: WidgetBuilder<Constant>) =
+            Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: WidgetBuilder<Constant>, rhs: string) = Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeRightExpr(lhs: string, rhs: string) = Ast.InfixAppExpr(lhs, "|>", rhs)
+
+        static member PipeLeftExpr(lhs: WidgetBuilder<Expr>, rhs: WidgetBuilder<Expr>) =
+            Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: WidgetBuilder<Constant>, rhs: WidgetBuilder<Expr>) =
+            Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: WidgetBuilder<Constant>, rhs: WidgetBuilder<Constant>) =
+            Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: string, rhs: WidgetBuilder<Expr>) = Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: WidgetBuilder<Expr>, rhs: WidgetBuilder<Constant>) =
+            Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: WidgetBuilder<Constant>, rhs: string) = Ast.InfixAppExpr(lhs, "<|", rhs)
+
+        static member PipeLeftExpr(lhs: string, rhs: string) = Ast.InfixAppExpr(lhs, "<|", rhs)


### PR DESCRIPTION
```fsharp
    [<Fact>]
    let ``InfixApp expressions``() =
        Oak() {
            AnonymousModule() {
                InfixAppExpr(ConstantExpr(Constant("a")), "|>", ConstantExpr(Constant("b")))

                PipeRightExpr(ConstantExpr(Constant("a")), ConstantExpr(Constant("b")))

                PipeRightExpr(Constant("a"), Constant("b"))

                PipeRightExpr("a", "b")

                PipeLeftExpr(ConstantExpr(Constant("a")), ConstantExpr(Constant("b")))

                PipeLeftExpr(Constant("a"), Constant("b"))

                PipeLeftExpr("a", "b")

            }
        }
        |> produces
            """
a |> b
a |> b
a |> b
a |> b
a <| b
a <| b
a <| b
"""
```