### PR TITLE
AST widget fixes

### DIFF
--- a/docs/widgets/Types.fsx
+++ b/docs/widgets/Types.fsx
@@ -8,6 +8,25 @@ index: 9
 
 (**
 # Types
+
+## Contents
+- [Overview](#overview)
+- [Primitive Types](#primitive-types)
+- [String Literals](#string-literals)
+- [Collection Types](#collection-types)
+- [Tuple Types](#tuple-types)
+- [Option Types](#option-types)
+- [Function Types](#function-types)
+- [Generic Types](#generic-types)
+- [Unit of Measure](#unit-of-measure)
+- [Type Abbreviations](#type-abbreviations)
+- [Type Constraints](#type-constraints)
+
+## Overview
+F# is a strongly-typed language with a rich type system. Types in F# range from simple primitives to complex user-defined types. This document provides examples of how to work with various F# types in the Fabulous.AST library.
+
+## Primitive Types
+F# includes various primitive types such as Boolean values, integers, floating-point numbers, characters, and strings.
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -19,59 +38,340 @@ open type Fabulous.AST.Ast
 
 Oak() {
     AnonymousModule() {
-        Value(ConstantPat(Constant "a"), Bool(false)).returnType(Boolean())
+        // Boolean
+        Value(ConstantPat(Constant "a"), Bool(false), Boolean())
 
-        Value(ConstantPat(Constant "b"), Byte(0uy)).returnType(Byte())
-        Value(ConstantPat(Constant "c"), SByte(1y)).returnType(SByte())
-        Value(ConstantPat(Constant "d"), Int16(1s)).returnType(Int16())
+        // Numeric types - integers
+        Value(ConstantPat(Constant "b"), Byte(0uy), Byte()) // 8-bit unsigned integer
+        Value(ConstantPat(Constant "c"), SByte(1y), SByte()) // 8-bit signed integer
+        Value(ConstantPat(Constant "d"), Int16(1s), Int16()) // 16-bit signed integer
+        Value(ConstantPat(Constant "e"), UInt16(1us), UInt16()) // 16-bit unsigned integer
+        Value(ConstantPat(Constant "f"), Int(1), Int()) // 32-bit signed integer
+        Value(ConstantPat(Constant "g"), UInt32(1u), UInt32()) // 32-bit unsigned integer
+        Value(ConstantPat(Constant "h"), Int64(1L), Int64()) // 64-bit signed integer
+        Value(ConstantPat(Constant "i"), UInt64(1UL), UInt64()) // 64-bit unsigned integer
 
-        Value(ConstantPat(Constant "e"), UInt16(1us)).returnType(UInt16())
+        // Native integers
+        Value(ConstantPat(Constant "j"), IntPtr(nativeint 1), IntPtr()) // Native signed integer
+        Value(ConstantPat(Constant "k"), UIntPtr(unativeint 1), UIntPtr()) // Native unsigned integer
 
-        Value(ConstantPat(Constant "f"), Int(1)).returnType(Int())
-        Value(ConstantPat(Constant "g"), UInt32(1u)).returnType(UInt32())
-        Value(ConstantPat(Constant "h"), Int64(1L)).returnType(Int64())
+        // Floating-point types
+        Value(ConstantPat(Constant "l"), Decimal(1.0m), Decimal()) // Decimal (fixed-point number)
+        Value(ConstantPat(Constant "m"), Double(4.0), Double()) // 64-bit double-precision float
+        Value(ConstantPat(Constant "n"), Single(1.0f), Single()) // 32-bit single-precision float
+        Value(ConstantPat(Constant "r"), Float(1.0), Float()) // Alias for double
+        Value(ConstantPat(Constant "s"), Float32(1.0f), Float32()) // Alias for single
 
-        Value(ConstantPat(Constant "i"), UInt64(1UL)).returnType(UInt64())
+        // Character and string
+        Value(ConstantPat(Constant "o"), Char('c'), Char()) // Unicode character
+        Value(ConstantPat(Constant "p"), String("str"), String()) // Unicode text
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        Value(ConstantPat(Constant "j"), IntPtr(nativeint 1)).returnType(IntPtr())
+// produces the following code:
+(*** include-output ***)
 
-        Value(ConstantPat(Constant "k"), UIntPtr(unativeint 1)).returnType(UIntPtr())
+(**
+## String Literals
+F# supports multiple ways to represent string literals. Each representation has specific use cases.
+*)
 
-        Value(ConstantPat(Constant "l"), Decimal(1.0m)).returnType(Decimal())
+Oak() {
+    AnonymousModule() {
+        // Regular string with escape sequences
+        Value("regularString", String("Hello\nWorld!"), String())
 
-        Value(ConstantPat(Constant "m"), Constant("1.0")).returnType(Double())
+        // Verbatim string with @"..." syntax (preserves all whitespace and doesn't process escape sequences)
+        Value(
+            "verbatimString",
+            VerbatimString(
+                @"C:\Program Files\App
+Multiple lines
+    With indentation"
+            ),
+            String()
+        )
 
-        Value(ConstantPat(Constant "n"), Single(1.0f)).returnType(Single())
+        // Triple-quoted string with """...""" syntax (alternative verbatim string format)
+        Value("tripleQuotedString", InterpolatedStringExpr("""{"name": "John", "age": 30}"""), String())
 
-        Value(ConstantPat(Constant "o"), Char('c')).returnType(Char())
+        // Interpolated string (requires special support)
+        Value("interpolatedString", InterpolatedStringExpr([ Text("Hello, "); Expr(FillExpr("name"), 1) ]), String())
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        Value(ConstantPat(Constant "p"), String("str")).returnType(String())
+// produces the following code:
+(*** include-output ***)
 
-        Value(ConstantPat(Constant "q"), Constant("()")).returnType(Unit())
+(**
+## Collection Types
+F# provides several collection types, including arrays, lists, and sequences.
+*)
 
-        Value(ConstantPat(Constant "r"), Float(1.)).returnType(Float())
+Oak() {
+    AnonymousModule() {
+        // One-dimensional array
+        Value("array1d", ArrayExpr([ Int(1); Int(2); Int(3) ]), Array(Int()))
 
-        Value(ConstantPat(Constant "s"), Float32(1.f)).returnType(Float32())
+        // Two-dimensional array
+        Value("array2d", AppExpr("Array2D.create", [ Int(2); Int(2); Int(0) ]), Array("int", 2))
 
-        Value(ConstantPat(Constant "t"), Constant("System.Object()")).returnType(Obj())
+        // Lists
+        Value("list", ListExpr([ Int(1); Int(2); Int(3) ]), ListPostfix(Int()))
 
-        Value("u", ArrayExpr([ Int(1); Int(2) ])).returnType(Array(Int()))
+        // Sequence
+        Value("sequence", SeqExpr([ Int(1); Int(2); Int(3) ]), SeqPostfix(Int()))
 
-        Value("v", ListExpr([ Int(1); Int(2) ])).returnType(ListPostfix(Int()))
+        // Using alternative syntax with postfix notation
+        Value("listAlt", ListExpr([ String("a"); String("b") ]), ListPostfix(String()))
+        Value("seqAlt", SeqExpr([ Bool(true); Bool(false) ]), SeqPostfix(Boolean()))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        Value("w", SeqExpr([ Int(1); Int(2); Int(3) ])).returnType(SeqPostfix(Int()))
+// produces the following code:
+(*** include-output ***)
 
-        Value("x", TupleExpr([ Int(1); Int(2) ])).returnType(Tuple([ Int(); Int() ]))
+(**
+## Tuple Types
+Tuples group multiple values together in an ordered structure.
+*)
 
-        Value("y", AppExpr("Some", Int(1))).returnType(OptionPostfix(Int()))
+Oak() {
+    AnonymousModule() {
+        // Simple tuple (int * string)
+        Value("simpleTuple", TupleExpr([ Int(1); String("hello") ]), Tuple([ Int(); String() ]))
 
-        Value("z", StructTupleExpr([ Int(1); String("") ])).returnType(StructTuple([ Int(); String() ]))
+        // Triple tuple (int * bool * string)
+        Value("tripleTuple", TupleExpr([ Int(42); Bool(true); String("hello") ]), Tuple([ Int(); Boolean(); String() ]))
 
-        Value("funs", LambdaExpr(UnitPat(), ConstantUnit())).returnType(Funs(Unit(), Unit()))
+        // Nested tuples
+        Value(
+            "nestedTuple",
+            TupleExpr(
+                [ ConstantExpr(Int(1))
+                  TupleExpr([ ConstantExpr(String("nested")); ConstantExpr(Bool(true)) ]) ]
+            ),
+            Tuple([ Int(); Tuple([ String(); Boolean() ]) ])
+        )
 
-        Value("anonRecord", AnonRecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 1)) ]))
-            .returnType(AnonRecord([ "A", Int() ]))
+        // Struct tuple (value type)
+        Value("structTuple", StructTupleExpr([ Int(1); String("value") ]), StructTuple([ Int(); String() ]))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Option Types
+Option types represent values that might not exist.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Option with Some value
+        Value("someValue", AppExpr("Some", Int(42)), OptionPostfix(Int()))
+
+        // Option with None value
+        Value("noValue", Constant("None"), OptionPostfix(String()))
+
+        // Using the option in a match expression
+        Value(
+            "optionMatch",
+            MatchExpr(
+                "someValue",
+                [ MatchClauseExpr(LongIdentPat("Some", "x"), Constant("x"))
+                  MatchClauseExpr(Constant("None"), Int(0)) ]
+            ),
+            Int()
+        )
+
+        // Alternative syntax
+        Value("someAlt", AppExpr("Some", String("text")), OptionPostfix(String()))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Function Types
+F# is a functional-first language where functions are first-class values.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Simple function (int -> string)
+        Value("stringify", LambdaExpr(NamedPat("x"), AppExpr("string", Constant("x"))), Funs([ Int() ], String()))
+
+        // Function with multiple parameters (int -> int -> int)
+        Value(
+            "add",
+            LambdaExpr([ NamedPat("x"); NamedPat("y") ], InfixAppExpr("x", "+", "y")),
+            Funs([ Int(); Int() ], Int())
+        )
+
+        // Higher-order function that takes a function as parameter
+        Value(
+            "applyTwice",
+            LambdaExpr(
+                ParenPat(
+                    TuplePat(
+                        [ ParameterPat(NamedPat("f"), Funs([ LongIdent("'a") ], LongIdent("'a")))
+                          ParameterPat(NamedPat("x"), LongIdent("'a")) ]
+                    )
+                ),
+                AppExpr("f", [ AppExpr("f", [ "x" ]) ])
+            ),
+            Funs([ Funs([ LongIdent("'a") ], LongIdent("'a")); LongIdent("'a") ], LongIdent("'a"))
+        )
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Generic Types
+F# supports generic types with type parameters.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Generic list of strings
+        Value("stringList", ListExpr([ String("a"); String("b") ]), ListPrefix(String()))
+
+        // Generic dictionary with string keys and int values
+        Value("dictionary", AppExpr("Dictionary"), AppPrefix(LongIdent("Dictionary"), [ String(); Int() ]))
+
+        // Generic Result type (for success/failure scenarios)
+        Value("result", AppExpr("Ok", Int(42)), ResultPrefix(Int(), String()))
+
+        // Using a custom generic type
+        Value("customGeneric", AppExpr("CustomType", String("data")), AppPrefix("CustomType", [ String() ]))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Unit of Measure
+F# supports units of measure for type-safe numeric calculations.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Simple measurement
+        Value("distance", ConstantExpr(ConstantMeasure("10.0", "m")), AppPrefix(Float(), "m"))
+
+        // Compound measurement
+        Value(
+            "speed",
+            ConstantExpr(ConstantMeasure("55.0", MeasureDivide("km", "h"))),
+            AppPrefix(Float(), Tuple([ "km"; "h" ], "/"))
+        )
+
+        // Squared units
+        Value(
+            "area",
+            ConstantExpr(ConstantMeasure("100.0", MeasurePower("m", Integer("2")))),
+            AppPrefix(Float(), MeasurePowerType("m", Integer("2")))
+        )
+
+        // Calculations with units
+        Value(
+            "calculatedSpeed",
+            InfixAppExpr(ConstantExpr(ConstantMeasure("100.0", "km")), "/", ConstantExpr(ConstantMeasure("2.0", "h"))),
+            AppPrefix(Float(), Tuple([ "km"; "h" ], "/"))
+        )
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Type Abbreviations
+Type abbreviations provide alternative names for existing types.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Simple type abbreviation
+        Abbrev("UserId", Int())
+
+        // Type abbreviation for a more complex type
+        Abbrev("UserMap", AppPrefix("Dictionary", [ String(); Int() ]))
+
+        // Using type abbreviations
+        Value("userId", Int(42), LongIdent("UserId"))
+
+        // Type abbreviation with a unit of measure
+        //Abbrev("Distance", MeasureSingle("m"))
+        Value("myDistance", ConstantExpr(ConstantMeasure("50.0", "m")), LongIdent("Distance"))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Type Constraints
+F# allows you to constrain type parameters to have certain properties.
+*)
+
+Oak() {
+    AnonymousModule() {
+        // Function with equality constraint
+        Function(
+            "areEqual",
+            ParenPat(
+                TuplePat(
+                    [ ParameterPat(NamedPat("a"), WithGlobal("'T", ConstraintSingle("'T", "equality")))
+                      ParameterPat(NamedPat("b"), "'T") ]
+                )
+            ),
+            InfixAppExpr("a", "=", "b")
+        )
+
+        // Function with comparison constraint
+        Function(
+            "max",
+            ParenPat(
+                TuplePat(
+                    [ ParameterPat(NamedPat("a"), WithGlobal("'T", ConstraintSingle("'T", "comparison")))
+                      ParameterPat(NamedPat("b"), "'T") ]
+                )
+            ),
+            IfThenElifExpr([ IfThenExpr(InfixAppExpr("a", ">", "b"), ConstantExpr("a")) ], ConstantExpr("b"))
+        )
     }
 }
 |> Gen.mkOak

--- a/docs/widgets/Types.fsx
+++ b/docs/widgets/Types.fsx
@@ -331,7 +331,7 @@ Oak() {
         Value("userId", Int(42), LongIdent("UserId"))
 
         // Type abbreviation with a unit of measure
-        //Abbrev("Distance", MeasureSingle("m"))
+        Abbrev("Distance", "m")
         Value("myDistance", ConstantExpr(ConstantMeasure("50.0", "m")), LongIdent("Distance"))
     }
 }

--- a/docs/widgets/UnitsofMeasure.fsx
+++ b/docs/widgets/UnitsofMeasure.fsx
@@ -21,7 +21,7 @@ Oak() {
     AnonymousModule() {
         Measure("cm")
 
-        Measure("ml", MeasurePower(LongIdent "cm", Integer "3"))
+        Measure("ml", MeasurePowerType("cm", Integer "3"))
 
         Measure("m")
 
@@ -29,14 +29,7 @@ Oak() {
 
         Measure("kg")
 
-        Measure(
-            "N",
-            Tuple(
-                [ AppPostfix(LongIdent "kg", LongIdent "m")
-                  MeasurePower(LongIdent "s", Integer "2") ],
-                "/"
-            )
-        )
+        Measure("N", Tuple([ AppPrefix(LongIdent "kg", LongIdent "m"); MeasurePowerType("s", Integer "2") ], "/"))
     }
 }
 |> Gen.mkOak

--- a/src/Fabulous.AST.Tests/Constant.fs
+++ b/src/Fabulous.AST.Tests/Constant.fs
@@ -23,6 +23,7 @@ module Constant =
                 ConstantExpr(UInt64(0UL))
                 ConstantExpr(IntPtr(System.IntPtr.Zero))
                 ConstantExpr(UIntPtr(System.UIntPtr.Zero))
+                ConstantExpr(Float(System.Math.PI))
                 ConstantExpr(Decimal(4.0m))
                 ConstantExpr(Double(4.0))
                 ConstantExpr(Single(4.0f))
@@ -100,14 +101,15 @@ true
 0UL
 nativeint 0
 unativeint 0
+3.141592653589793
 4.0m
-4
+4.0
 4.0f
 "hello"
 'c'
 4.0f
 A
-```I'm a constant```
+``I'm a constant``
 ()
 2<cm>
 2<m>

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -131,6 +131,7 @@
         <Compile Include="Attributes\Attributes.fs" />
         <Compile Include="Types\Types.fs" />
         <Compile Include="Types\LongIdent.fs" />
+        <Compile Include="Types\Measures.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -130,7 +130,7 @@
         <Compile Include="Patterns\ListCons.fs" />
         <Compile Include="Attributes\Attributes.fs" />
         <Compile Include="Types\Types.fs" />
-        <Compile Include="Types\LongIdentTests.fs" />
+        <Compile Include="Types\LongIdent.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
@@ -101,12 +101,14 @@ let x, y, z = 1, 2, 3
             AnonymousModule() {
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12)), Int())
 
-                Value(ConstantPat(Constant("z")), ConstantExpr(VerbatimString(Int(12))))
+                Value(ConstantPat(Constant("y")), ConstantExpr(VerbatimString(Int(12))))
+                Value(ConstantPat(Constant("z")), ConstantExpr(TripleQuotedString(Int(12))))
             }
         }
         |> produces
             "
 let x: int = 12
+let y = @\"12\"
 let z = \"\"\"12\"\"\"
 "
 

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
@@ -14,7 +14,7 @@ module UnitsOfMeasure =
             AnonymousModule() {
                 Measure("cm").xmlDocs([ "Cm, centimeters." ])
 
-                Measure("ml", MeasurePower(LongIdent "cm", Integer "3")).xmlDocs([ "Ml, milliliters." ])
+                Measure("ml", MeasurePowerType(LongIdent "cm", Integer "3")).xmlDocs([ "Ml, milliliters." ])
 
                 Measure("g").xmlDocs([ "Mass, grams." ])
                 Measure("kg").xmlDocs([ "Mass, kilograms." ])
@@ -29,7 +29,7 @@ module UnitsOfMeasure =
                     "N",
                     Tuple(
                         [ AppPostfix(LongIdent "kg", LongIdent "m")
-                          MeasurePower(LongIdent "s", Integer "2") ],
+                          MeasurePowerType(LongIdent "s", Integer "2") ],
                         "/"
                     )
                 )
@@ -37,7 +37,7 @@ module UnitsOfMeasure =
 
                 Measure("bar").xmlDocs([ "Pressure, bar." ])
 
-                Measure("Pa", Tuple([ LongIdent("N"); MeasurePower(LongIdent "m", Integer "2") ], "/"))
+                Measure("Pa", Tuple([ LongIdent("N"); MeasurePowerType(LongIdent "m", Integer "2") ], "/"))
                     .xmlDocs([ "Pressure, Pascals" ])
 
                 Measure("ml").xmlDocs([ "Volume, milliliters." ])

--- a/src/Fabulous.AST.Tests/Types/LongIdent.fs
+++ b/src/Fabulous.AST.Tests/Types/LongIdent.fs
@@ -7,7 +7,7 @@ open Fabulous.AST
 
 open type Ast
 
-module LongIdentTests =
+module LongIdent =
 
     [<Fact>]
     let ``Long identifier with multiple parts``() =

--- a/src/Fabulous.AST.Tests/Types/Measures.fs
+++ b/src/Fabulous.AST.Tests/Types/Measures.fs
@@ -1,0 +1,242 @@
+namespace Fabulous.AST.Tests.Types
+
+open Xunit
+open Fabulous.AST.Tests
+open Fabulous.AST
+
+open type Ast
+
+module Measures =
+
+    [<Fact>]
+    let ``Basic measure``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Constant("1.0"), MeasureSingle("cm"))) } }
+        |> produces
+            """
+1.0<cm>
+"""
+
+    [<Fact>]
+    let ``Integer with measure``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Int(42), MeasureSingle("kg"))) } }
+        |> produces
+            """
+42<kg>
+"""
+
+    [<Fact>]
+    let ``Float with measure``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Float(3.14), MeasureSingle("rad"))) } }
+        |> produces
+            """
+3.14<rad>
+"""
+
+    [<Fact>]
+    let ``Decimal with measure``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Decimal(9.99m), MeasureSingle("$"))) } }
+        |> produces
+            """
+9.99m<$>
+"""
+
+    [<Fact>]
+    let ``Measure division``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Float(55.0), MeasureDivide("km", "h"))) } }
+        |> produces
+            """
+55.0<km / h>
+"""
+
+    [<Fact>]
+    let ``Measure multiplication (operator)``() =
+        Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Int(10), MeasureOperator("*", "N", "m"))) } }
+        |> produces
+            """
+10<N * m>
+"""
+
+    [<Fact>]
+    let ``Measure sequence``() =
+        Oak() {
+            AnonymousModule() {
+                ConstantExpr(ConstantMeasure(Double(42.0), MeasureSeq([ "kg"; "*"; "m"; "/"; "s"; "^"; "2" ])))
+            }
+        }
+        |> produces
+            """
+42.0<kg * m / s ^ 2>
+"""
+
+    [<Fact>]
+    let ``Measure power (integer)``() =
+        Oak() {
+            AnonymousModule() {
+                ConstantExpr(ConstantMeasure(Float(100.0), MeasurePower(MeasureSingle("m"), Integer("2"))))
+            }
+        }
+        |> produces
+            """
+100.0<m^2>
+"""
+
+    [<Fact>]
+    let ``Measure power (negative)``() =
+        Oak() {
+            AnonymousModule() {
+                ConstantExpr(ConstantMeasure(Float(10.0), MeasureSeq([ MeasurePower("s", Negate(Integer("1"))) ])))
+            }
+        }
+        |> produces
+            """
+10.0<s^-1>
+"""
+
+    [<Fact>]
+    let ``Measure power (rational)``() =
+        Oak() {
+            AnonymousModule() { ConstantExpr(ConstantMeasure(Float(2.0), MeasurePower("L", Rational("1", "/", "2")))) }
+        }
+        |> produces
+            """
+2.0<L^(1/2)>
+"""
+
+    [<Fact>]
+    let ``Measure with parentheses``() =
+        Oak() {
+            AnonymousModule() {
+                ConstantExpr(
+                    ConstantMeasure(Double(5.0), MeasureParen(MeasureDivide(MeasureSingle("J"), MeasureSingle("K"))))
+                )
+            }
+        }
+        |> produces
+            """
+5.0<(J / K)>
+"""
+
+    [<Fact>]
+    let ``Multiple measure types in one module``() =
+        Oak() {
+            AnonymousModule() {
+                // Define custom measures
+                Measure("m")
+                Measure("s")
+
+                // Simple single measures
+                Value("length", ConstantExpr(ConstantMeasure(Float(10.0), "m")), AppPrefix(Float(), "m"))
+
+                Value("time", ConstantExpr(ConstantMeasure(Float(5.0), "s")), AppPrefix(Float(), "s"))
+
+                // Derived measures
+                Value("speed", InfixAppExpr("length", "/", "time"), AppPrefix(Float(), Tuple([ "m"; "s" ], "/")))
+
+                // Complex measures with powers
+                Value(
+                    "area",
+                    ConstantExpr(ConstantMeasure(Float(50.0), MeasurePower("m", Integer(2)))),
+                    AppPrefix(Float(), MeasurePowerType("m", Integer(2)))
+                )
+
+                Value(
+                    "acceleration",
+                    ConstantExpr(ConstantMeasure(Float(9.81), MeasureDivide("m", MeasurePower("s", Integer(2))))),
+                    AppPrefix(Float(), Tuple([ LongIdent "m"; MeasurePowerType("s", Integer("2")) ], "/"))
+
+                )
+            }
+        }
+        |> produces
+            """
+[<Measure>]
+type m
+
+[<Measure>]
+type s
+
+let length: float<m> = 10.0<m>
+let time: float<s> = 5.0<s>
+let speed: float<m / s> = length / time
+let area: float<m^2> = 50.0<m^2>
+let acceleration: float<m / s^2> = 9.81<m / s^2>
+"""
+
+    [<Fact>]
+    let ``Predefined measures``() =
+        Oak() {
+            AnonymousModule() {
+                // Define measure types
+                Measure("s")
+                Measure("min")
+
+                // Time units
+                Value("seconds", ConstantExpr(ConstantMeasure(Float(1.0), "s")), AppPrefix(Float(), "s"))
+
+                Value("minutes", ConstantExpr(ConstantMeasure(Float(60.0), "s")), AppPrefix(Float(), "s"))
+
+                Value("hours", ConstantExpr(ConstantMeasure(Float(3600.0), "s")), AppPrefix(Float(), "s"))
+
+                // Convert between units
+                Value("minutesFromSeconds", InfixAppExpr("seconds", "/", Float(60.0)), AppPrefix(Float(), "min"))
+            }
+        }
+        |> produces
+            """
+[<Measure>]
+type s
+
+[<Measure>]
+type min
+
+let seconds: float<s> = 1.0<s>
+let minutes: float<s> = 60.0<s>
+let hours: float<s> = 3600.0<s>
+let minutesFromSeconds: float<min> = seconds / 60.0
+"""
+
+    [<Fact>]
+    let ``Define custom measure types``() =
+        Oak() {
+            AnonymousModule() {
+                // Define custom measures with the [< Measure >] attribute
+                Measure("m")
+
+                Measure("s")
+
+                Measure("kg")
+
+                // Define derived measure
+                Measure("N") |> _.xmlDocs([ "Newton: kg·m/s²" ])
+
+                // Use custom measures
+                Value("mass", Float(10.0), AppPrefix(Float(), "kg"))
+
+                Value(
+                    "acceleration",
+                    Float(9.81),
+                    AppPrefix(Float(), Tuple([ LongIdent "m"; MeasurePowerType("s", Integer("2")) ], "/"))
+                )
+
+                Value("force", InfixAppExpr("mass", "*", "acceleration"), AppPrefix(Float(), "N"))
+            }
+        }
+        |> produces
+            """
+[<Measure>]
+type m
+
+[<Measure>]
+type s
+
+[<Measure>]
+type kg
+
+/// Newton: kg·m/s²
+[<Measure>]
+type N
+
+let mass: float<kg> = 10.0
+let acceleration: float<m / s^2> = 9.81
+let force: float<N> = mass * acceleration
+"""

--- a/src/Fabulous.AST.Tests/Types/Types.fs
+++ b/src/Fabulous.AST.Tests/Types/Types.fs
@@ -138,7 +138,7 @@ let t: obj = obj
 
                 Value(ConstantPat(Constant("c")), ConstantExpr(Bool(false)), Tuple([ String(); String() ]))
 
-                Value(ConstantPat(Constant("c")), ConstantExpr(Bool(false)), MeasurePower("cm", Integer(2)))
+                Value(ConstantPat(Constant("c")), ConstantExpr(Bool(false)), MeasurePowerType("cm", Integer(2)))
 
                 Value(ConstantPat(Constant("c")), ConstantExpr(Bool(false)), Funs([ Int() ], String()))
             }

--- a/src/Fabulous.AST/Widgets/Expressions/App.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/App.fs
@@ -78,6 +78,12 @@ module AppBuilders =
         static member AppExpr(name: string, item: string) =
             Ast.AppExpr(name, [ Ast.Constant(item) ])
 
+        static member AppExpr(name: WidgetBuilder<Expr>) = Ast.AppExpr(name, [])
+
+        static member AppExpr(name: WidgetBuilder<Constant>) = Ast.AppExpr(name, [])
+
+        static member AppExpr(name: string) = Ast.AppExpr(name, [])
+
         static member FailWithExpr(items: WidgetBuilder<Expr> list) =
             Ast.AppExpr(Ast.Constant("failwith"), items)
 

--- a/src/Fabulous.AST/Widgets/Expressions/InfixApp.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/InfixApp.fs
@@ -125,7 +125,7 @@ module InfixAppBuilders =
             Ast.InfixAppExpr(lhs, operator, Ast.Constant(rhs))
 
         /// <summary>
-        /// Create an infix application expression with an expression left-hand side and constant right-hand side.
+        /// Creates an infix application expression with an expression left-hand side and constant right-hand side.
         /// </summary>
         /// <param name="lhs">The left-hand side expression.</param>
         /// <param name="operator">The infix operator.</param>

--- a/src/Fabulous.AST/Widgets/Expressions/Lambda.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Lambda.fs
@@ -32,6 +32,9 @@ module LambdaBuilders =
                 )
             )
 
+        static member LambdaExpr(parameter: WidgetBuilder<Pattern>, value: WidgetBuilder<Expr>) =
+            Ast.LambdaExpr([ parameter ], value)
+
         static member LambdaExpr(parameter: WidgetBuilder<Pattern>, value: WidgetBuilder<Constant>) =
             Ast.LambdaExpr([ parameter ], Ast.ConstantExpr(value))
 
@@ -53,5 +56,13 @@ module LambdaBuilders =
             let parameters = parameters |> List.map Ast.ConstantPat
             Ast.LambdaExpr(parameters, value)
 
+        static member LambdaExpr(parameters: string list, value: WidgetBuilder<Constant>) =
+            let parameters = parameters |> List.map Ast.ConstantPat
+            Ast.LambdaExpr(parameters, Ast.ConstantExpr(value))
+
         static member LambdaExpr(parameters: string list, value: string) =
             Ast.LambdaExpr(parameters |> List.map Ast.ConstantPat, Ast.Constant(value))
+
+        static member LambdaExpr(parameters: string, value: string) =
+            let parameters = [ parameters ] |> List.map Ast.ConstantPat
+            Ast.LambdaExpr(parameters, Ast.Constant(value))

--- a/src/Fabulous.AST/Widgets/Measure.fs
+++ b/src/Fabulous.AST/Widgets/Measure.fs
@@ -235,13 +235,35 @@ module MeasureBuilders =
         /// <summary>Creates a measure raised to a power from string values.</summary>
         /// <param name="measure">The base measure as a string.</param>
         /// <param name="node">The power as a string.</param>
+        static member MeasurePower(measure: string, node: WidgetBuilder<RationalConstNode>) =
+            WidgetBuilder<Measure>(
+                Measure.WidgetMeasurePowerKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    [| Measure.LHS.WithValue(Ast.MeasureSingle(measure).Compile())
+                       Measure.RHS.WithValue(node.Compile()) |],
+                    Array.empty
+                )
+            )
+
         static member MeasurePower(measure: string, node: string) =
             WidgetBuilder<Measure>(
                 Measure.WidgetMeasurePowerKey,
                 AttributesBundle(
                     StackList.empty(),
                     [| Measure.LHS.WithValue(Ast.MeasureSingle(measure).Compile())
-                       Measure.RHS.WithValue(Ast.MeasureSingle(node).Compile()) |],
+                       Measure.RHS.WithValue(Ast.Integer(node).Compile()) |],
+                    Array.empty
+                )
+            )
+
+        static member MeasurePower(measure: WidgetBuilder<Measure>, node: string) =
+            WidgetBuilder<Measure>(
+                Measure.WidgetMeasurePowerKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    [| Measure.LHS.WithValue(measure.Compile())
+                       Measure.RHS.WithValue(Ast.Integer(node).Compile()) |],
                     Array.empty
                 )
             )

--- a/src/Fabulous.AST/Widgets/Measure.fs
+++ b/src/Fabulous.AST/Widgets/Measure.fs
@@ -204,6 +204,34 @@ module MeasureBuilders =
                 )
             )
 
+        /// <summary>Creates a division measure between two measures.</summary>
+        /// <param name="lhs">The numerator measure.</param>
+        /// <param name="rhs">The denominator measure.</param>
+        static member MeasureDivide(lhs: string, rhs: WidgetBuilder<Measure>) =
+            WidgetBuilder<Measure>(
+                Measure.WidgetMeasureDivideKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    [| Measure.LHS.WithValue(Ast.MeasureSingle(lhs).Compile())
+                       Measure.RHS.WithValue(rhs.Compile()) |],
+                    Array.empty
+                )
+            )
+
+        /// <summary>Creates a division measure between two measures.</summary>
+        /// <param name="lhs">The numerator measure.</param>
+        /// <param name="rhs">The denominator measure.</param>
+        static member MeasureDivide(lhs: WidgetBuilder<Measure>, rhs: string) =
+            WidgetBuilder<Measure>(
+                Measure.WidgetMeasureDivideKey,
+                AttributesBundle(
+                    StackList.empty(),
+                    [| Measure.LHS.WithValue(lhs.Compile())
+                       Measure.RHS.WithValue(Ast.MeasureSingle(rhs).Compile()) |],
+                    Array.empty
+                )
+            )
+
         /// <summary>Creates a division measure between two string measures.</summary>
         /// <param name="lhs">The numerator measure as a string.</param>
         /// <param name="rhs">The denominator measure as a string.</param>

--- a/src/Fabulous.AST/Widgets/Types/MeasurePower.fs
+++ b/src/Fabulous.AST/Widgets/Types/MeasurePower.fs
@@ -19,7 +19,7 @@ module TypeMeasurePower =
 [<AutoOpen>]
 module TypeMeasurePowerBuilders =
     type Ast with
-        static member MeasurePower(value: WidgetBuilder<Type>, rational: WidgetBuilder<RationalConstNode>) =
+        static member MeasurePowerType(value: WidgetBuilder<Type>, rational: WidgetBuilder<RationalConstNode>) =
             WidgetBuilder<Type>(
                 TypeMeasurePower.WidgetKey,
                 AttributesBundle(
@@ -30,5 +30,5 @@ module TypeMeasurePowerBuilders =
                 )
             )
 
-        static member MeasurePower(value: string, rational: WidgetBuilder<RationalConstNode>) =
-            Ast.MeasurePower(Ast.LongIdent value, rational)
+        static member MeasurePowerType(value: string, rational: WidgetBuilder<RationalConstNode>) =
+            Ast.MeasurePowerType(Ast.LongIdent value, rational)


### PR DESCRIPTION
This pull request introduces extensive updates to the documentation, tests, and type handling in the Fabulous.AST library. The changes include adding detailed documentation for F# types, improving type representations in the codebase, and enhancing test coverage for constants, units of measure, and type abbreviations. Additionally, some files were renamed to better align with naming conventions.

### Documentation Enhancements:
* Added comprehensive documentation for F# types in `docs/widgets/Types.fsx`, covering topics such as primitive types, collection types, tuples, options, functions, generics, and more. Each section includes examples and generated code snippets. [[1]](diffhunk://#diff-79992cc5cd958869440582d8dffe48798f272eb7260072f464278c4af1c5a4c8R11-R29) [[2]](diffhunk://#diff-79992cc5cd958869440582d8dffe48798f272eb7260072f464278c4af1c5a4c8L22-R374)

### Code Improvements:
* Updated type representations to use more descriptive constructors, such as replacing `MeasurePower` with `MeasurePowerType` and improving tuple representations for units of measure. [[1]](diffhunk://#diff-111db2ac29773bacd949e482908ce0bea6c8b1abdaf69e1b7d9ef0f403693f32L24-R32) [[2]](diffhunk://#diff-8f72f84bd24a4555a8d47f77150a13d8c22c8c0433c4e046a7c627fa6ab61026L17-R17) [[3]](diffhunk://#diff-8f72f84bd24a4555a8d47f77150a13d8c22c8c0433c4e046a7c627fa6ab61026L32-R40)

### Test Enhancements:
* Added a new constant for `Math.PI` and updated related test cases in `src/Fabulous.AST.Tests/Constant.fs`. [[1]](diffhunk://#diff-eee96b7ae88079fb15180b6a77f5152ec743c64511d34bc796c1197e1d7165a6R26) [[2]](diffhunk://#diff-eee96b7ae88079fb15180b6a77f5152ec743c64511d34bc796c1197e1d7165a6R104-R112)
* Improved test coverage for top-level bindings, including support for verbatim and triple-quoted strings in `src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs`.

### File Renaming:
* Renamed `LongIdentTests.fs` to `LongIdent.fs` and added a new file `Measures.fs` to better organize type-related tests. [[1]](diffhunk://#diff-04f061005551cbf9d8655fe779a506b27aec09dd614c6a1a7c0100eb67991811L133-R134) [[2]](diffhunk://#diff-2aafadb0399e20d86fcc07b191843b434edc0be17be2ea554e6b8319e699bf6aL10-R10)