### PR TITLE
chore(docs): AI cooked the XML Docs

### DIFF
--- a/src/Fabulous.AST/DSL/Primitives.fs
+++ b/src/Fabulous.AST/DSL/Primitives.fs
@@ -107,7 +107,7 @@ and [<Struct>] WidgetCollectionAttribute =
     { Key: WidgetCollectionAttributeKey
       Value: ArraySlice<Widget> }
 
-/// Represents a virtual UI element such as a Label, a Button, etc.
+/// Uniform representation of AST nodes.
 and [<Struct>] Widget =
     { Key: WidgetKey
       ScalarAttributes: ScalarAttribute array


### PR DESCRIPTION
Or maybe this is something that was used in the Fabulous UI projects?

### Before

```fsharp
/// Represents a virtual UI element such as a Label, a Button, etc.
and [<Struct>] Widget =
    { Key: WidgetKey
      ScalarAttributes: ScalarAttribute array
      WidgetAttributes: WidgetAttribute[]
      WidgetCollectionAttributes: WidgetCollectionAttribute array }
```

### After

```fsharp
/// Uniform representation of an AST node
and [<Struct>] Widget =
    { Key: WidgetKey
      ScalarAttributes: ScalarAttribute array
      WidgetAttributes: WidgetAttribute[]
      WidgetCollectionAttributes: WidgetCollectionAttribute array }
```