### PR TITLE
feat: add support for abstract slots to be static; fix xml docs for static slots - Fixes #175

### DIFF
--- a/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
@@ -678,3 +678,57 @@ type X =
     abstract Add: a: int -> b: int -> int with public get, set
     abstract Add: a: int * b: int -> int with public get, set
 """
+
+    [<Fact>]
+    let ``Abstract member with static modifier``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("X") {
+                    AbstractMember(
+                        "Add",
+                        [ ("a", Int()); ("b", Int()) ],
+                        Int(),
+                        false
+                    ).toStatic()
+
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true).toStatic()
+
+                }
+            }
+        }
+        |> produces
+            """
+type X =
+    static abstract Add: a: int -> b: int -> int
+    static abstract Add: a: int * b: int -> int
+"""
+    [<Fact>]
+    let ``Abstract member with xml documentation``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("X") {
+                    AbstractMember(
+                        "Add",
+                        [ ("a", Int()); ("b", Int()) ],
+                        Int(),
+                        false
+                    ).xmlDocs([ "<summary>"; "Summary"; "</summary>" ])
+
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true)
+                        .xmlDocs([ "<summary>"; "Second Summary"; "</summary>" ])
+
+                }
+            }
+        }
+        |> produces
+            """
+type X =
+    /// <summary>
+    /// Summary
+    /// </summary>
+    abstract Add: a: int -> b: int -> int
+    /// <summary>
+    /// Second Summary
+    /// </summary>
+    abstract Add: a: int * b: int -> int
+"""

--- a/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
@@ -684,12 +684,7 @@ type X =
         Oak() {
             AnonymousModule() {
                 TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false
-                    ).toStatic()
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), false).toStatic()
 
                     AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true).toStatic()
 
@@ -702,17 +697,14 @@ type X =
     static abstract Add: a: int -> b: int -> int
     static abstract Add: a: int * b: int -> int
 """
+
     [<Fact>]
     let ``Abstract member with xml documentation``() =
         Oak() {
             AnonymousModule() {
                 TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false
-                    ).xmlDocs([ "<summary>"; "Summary"; "</summary>" ])
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), false)
+                        .xmlDocs([ "<summary>"; "Summary"; "</summary>" ])
 
                     AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true)
                         .xmlDocs([ "<summary>"; "Second Summary"; "</summary>" ])

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
@@ -131,8 +131,7 @@ module AbstractSlot =
                 | parameters, returnType -> Type.Funs(TypeFunsNode(parameters, returnType, Range.Zero))
 
             let isStatic =
-                Widgets.tryGetScalarValue widget IsStatic
-                |> ValueOption.defaultValue false
+                Widgets.tryGetScalarValue widget IsStatic |> ValueOption.defaultValue false
 
             let leadingKeywords =
                 MultipleTextsNode.Create(
@@ -140,7 +139,7 @@ module AbstractSlot =
                         [ SingleTextNode.``static``; SingleTextNode.``abstract`` ]
                     else
                         [ SingleTextNode.``abstract`` ]
-                    )
+                )
 
             let typeParams =
                 Widgets.tryGetNodeFromWidget widget MemberDefn.TypeParams


### PR DESCRIPTION
# Description

AbstractSlot XmlDocs attribute references the MemberDefn XmlDocs attribute so that the modifier can be used without explicit reference to `AbstractMemberModifiers` extension method.

The PR also adds a reference to `IsStatic`, and rounds out the explicit `AbstractMemberModifiers` by adding explicit extensions for xmldocs, attributes, and toStatic.

Tests are added to prevent regression for xml docs, and to confirm functionality of toStatic.

---

Fixes #175 