### PR TITLE
fix: three audit findings (Delegate lazy-seq, ObjExpr failwith, Measure typo)

### DIFF
--- a/src/Fabulous.AST/Widgets/Expressions/ObjExpr.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/ObjExpr.fs
@@ -141,7 +141,10 @@ type ObjExprYieldExtensions =
         | MemberDefn.Member(bindingNode) ->
             let widget = Ast.EscapeHatch(bindingNode).Compile()
             { Widgets = MutStackArray1.One(widget) }
-        | _ -> failwith "Only MemberDefn.Member is supported in ObjExpr"
+        | other ->
+            invalidArg
+                "x"
+                $"ObjExpr only accepts MemberDefn.Member items (e.g. Member(...)). Got: %A{other.GetType().Name}"
 
     [<Extension>]
     static member inline Yield

--- a/src/Fabulous.AST/Widgets/Measure.fs
+++ b/src/Fabulous.AST/Widgets/Measure.fs
@@ -10,7 +10,7 @@ module RationalConstNode =
 
     let DivOp = Attributes.defineScalar<string> "DivOp"
 
-    let Denominator = Attributes.defineScalar<string> "DivOp"
+    let Denominator = Attributes.defineScalar<string> "Denominator"
 
     let Node = Attributes.defineWidget "Node"
 

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Delegate.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Delegate.fs
@@ -23,16 +23,16 @@ module Delegate =
 
             let returnType = Widgets.getNodeFromWidget<Type> widget Return
 
-            let parameters = Widgets.getScalarValue widget Parameters
+            let parameters = Widgets.getScalarValue widget Parameters |> List.ofSeq
+            let lastIndex = List.length parameters - 1
 
             let parameters =
                 parameters
-                |> Seq.mapi(fun i t ->
-                    if i = Seq.length parameters - 1 then
+                |> List.mapi(fun i t ->
+                    if i = lastIndex then
                         (t, SingleTextNode.arrow)
                     else
                         (t, SingleTextNode.star))
-                |> List.ofSeq
 
             let xmlDocs =
                 Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs


### PR DESCRIPTION
## Summary

Three small, self-contained bug fixes surfaced by the Widgets/ audit performed after PR #178 (which covered MemberDefinitions/).

| File | Issue | Fix |
|---|---|---|
| `Widgets/TypeDefinitions/Delegate.fs:31` | `Seq.length parameters` evaluated inside `Seq.mapi` — O(n²), and re-walks a lazy seq each iteration (same footgun fixed in AbstractSlot during #178) | Materialize parameters with `List.ofSeq` once; capture `lastIndex` before the map |
| `Widgets/Expressions/ObjExpr.fs:144` | `failwith` for argument-shape mismatch inside a CE `Yield` extension; raises the wrong exception type and gives no context about what was offered | Replace with `invalidArg "x" "ObjExpr only accepts MemberDefn.Member items (e.g. Member(...)). Got: <case>"` |
| `Widgets/Measure.fs:13` | `let Denominator = Attributes.defineScalar<string> "Denominator"` was written as `"DivOp"` — almost certainly a copy-paste leftover from the sibling scalar one line above | Rename the key string to `"Denominator"` |

The `Measure.fs` change has no functional impact (`Attributes.defineScalar` auto-generates a unique numeric key; the string is informational/debug-only). The `Delegate.fs` change is a real performance + correctness fix on lazy sequences. The `ObjExpr.fs` change improves error UX with no behavior change for valid inputs.

## Verification

- `dotnet fsi build.fsx` green: lint, build (net8.0/net10.0/netstandard2.1), tests, docs, pack
- `dotnet test`: 780/780 pass on both `net8.0` and `net10.0`

## Follow-ups (not in this PR)

The same audit identified a large mechanical cleanup opportunity — ~46 sites of `ValueOption.map Some |> defaultValue None` across 24 files, and ~28 files storing lazy `Seq.map Gen.mkOak` in `WithValue` calls. Both are fixable mechanically using the patterns established in #178 (`ValueOption.toOption` and `Seq.toArray` respectively). I'll open a separate sweep PR for that — kept out of this PR to keep the diff reviewable.