### PR TITLE
refactor: voption / lazy-seq sweep across all widgets

### DIFF
--- a/src/Fabulous.AST/Widgets/AttributeNode.fs
+++ b/src/Fabulous.AST/Widgets/AttributeNode.fs
@@ -14,15 +14,12 @@ module AttributeNode =
 
     let WidgetKey =
         Widgets.register "AttributeNode" (fun widget ->
-            let expr =
-                Widgets.tryGetNodeFromWidget widget Value
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let expr = Widgets.tryGetNodeFromWidget widget Value |> ValueOption.toOption
 
             let target =
                 Widgets.tryGetScalarValue widget Target
-                |> ValueOption.map(fun target -> Some(SingleTextNode.Create(target)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map SingleTextNode.Create
+                |> ValueOption.toOption
 
             let typeName = Widgets.getScalarValue widget TypeName
 

--- a/src/Fabulous.AST/Widgets/Expressions/AnonStructRecord.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/AnonStructRecord.fs
@@ -46,7 +46,7 @@ module AnonStructRecordBuilders =
             WidgetBuilder<Expr>(
                 AnonStructRecord.WidgetKey,
                 AttributesBundle(
-                    StackList.one(AnonStructRecord.Fields.WithValue(fields |> Seq.map Gen.mkOak)),
+                    StackList.one(AnonStructRecord.Fields.WithValue(fields |> Seq.map Gen.mkOak |> Seq.toArray)),
                     copyInfo,
                     Array.empty
                 )

--- a/src/Fabulous.AST/Widgets/Expressions/App.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/App.fs
@@ -22,7 +22,7 @@ module AppBuilders =
     type Ast with
 
         static member AppExpr(name: WidgetBuilder<Expr>, items: WidgetBuilder<Expr> seq) =
-            let items = items |> Seq.map Gen.mkOak
+            let items = items |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 App.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/AppWithLambda.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/AppWithLambda.fs
@@ -56,8 +56,8 @@ module AppWithLambdaBuilders =
                 parameters: WidgetBuilder<Pattern> seq,
                 value: WidgetBuilder<Expr>
             ) =
-            let arguments = arguments |> Seq.map Gen.mkOak
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let arguments = arguments |> Seq.map Gen.mkOak |> Seq.toArray
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 AppWithLambda.WidgetKey,
@@ -128,8 +128,8 @@ module AppWithLambdaBuilders =
                 arguments: WidgetBuilder<Expr> seq,
                 clauses: WidgetBuilder<MatchClauseNode> seq
             ) =
-            let clauses = clauses |> Seq.map Gen.mkOak
-            let arguments = arguments |> Seq.map Gen.mkOak
+            let clauses = clauses |> Seq.map Gen.mkOak |> Seq.toArray
+            let arguments = arguments |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 AppWithLambda.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/ArrayOrList.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/ArrayOrList.fs
@@ -35,7 +35,7 @@ module ArrayOrListBuilders =
         /// }
         /// </code>
         static member ListExpr(value: WidgetBuilder<Expr> seq) =
-            let parameters = value |> Seq.map Gen.mkOak
+            let parameters = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 ArrayOrList.WidgetKey,
@@ -108,7 +108,7 @@ module ArrayOrListBuilders =
         /// }
         /// </code>
         static member ArrayExpr(value: WidgetBuilder<Expr> seq) =
-            let parameters = value |> Seq.map Gen.mkOak
+            let parameters = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 ArrayOrList.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/Chain.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Chain.fs
@@ -17,7 +17,7 @@ module ChainBuilders =
     type Ast with
 
         static member ChainExpr(value: WidgetBuilder<ChainLink> seq) =
-            let chains = value |> Seq.map Gen.mkOak
+            let chains = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(Chain.WidgetKey, Chain.Value.WithValue(chains))
 

--- a/src/Fabulous.AST/Widgets/Expressions/CompExprBody.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/CompExprBody.fs
@@ -18,7 +18,7 @@ module CompExprBodyBuilders =
     type Ast with
 
         static member CompExprBodyExpr(values: WidgetBuilder<ComputationExpressionStatement> seq) =
-            let statements = values |> Seq.map Gen.mkOak
+            let statements = values |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(CompExprBody.WidgetKey, CompExprBody.Statements.WithValue(statements))
 

--- a/src/Fabulous.AST/Widgets/Expressions/FillExprNode.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/FillExprNode.fs
@@ -16,8 +16,8 @@ module FillExprNode =
 
             let identifier =
                 Widgets.tryGetScalarValue widget Identifier
-                |> ValueOption.map(fun x -> Some(SingleTextNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map SingleTextNode.Create
+                |> ValueOption.toOption
 
             FillExprNode(expr, identifier, Range.Zero))
 

--- a/src/Fabulous.AST/Widgets/Expressions/IfThenElif.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/IfThenElif.fs
@@ -33,7 +33,7 @@ module IfThenElif =
 module IfThenElifBuilders =
     type Ast with
         static member IfThenElifExpr(branches: WidgetBuilder<Expr> seq, elseExpr: WidgetBuilder<Expr>) =
-            let branches = branches |> Seq.map Gen.mkOak
+            let branches = branches |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 IfThenElif.WidgetKey,
@@ -71,7 +71,10 @@ module IfThenElifBuilders =
             Ast.IfThenElifExpr(branches, Ast.Constant(elseExpr))
 
         static member IfThenElifExpr(branches: WidgetBuilder<Expr> seq) =
-            WidgetBuilder<Expr>(IfThenElif.WidgetKey, IfThenElif.Branches.WithValue(branches |> Seq.map Gen.mkOak))
+            WidgetBuilder<Expr>(
+                IfThenElif.WidgetKey,
+                IfThenElif.Branches.WithValue(branches |> Seq.map Gen.mkOak |> Seq.toArray)
+            )
 
         static member IfThenElifExpr(branches: WidgetBuilder<Constant> seq) =
             Ast.IfThenElifExpr(branches |> Seq.map Ast.ConstantExpr)

--- a/src/Fabulous.AST/Widgets/Expressions/IndexRange.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/IndexRange.fs
@@ -12,15 +12,9 @@ module IndexRange =
 
     let WidgetKey =
         Widgets.register "IndexRange" (fun widget ->
-            let fromExpr =
-                Widgets.tryGetNodeFromWidget widget FromExpr
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let fromExpr = Widgets.tryGetNodeFromWidget widget FromExpr |> ValueOption.toOption
 
-            let toExpr =
-                Widgets.tryGetNodeFromWidget widget ToExpr
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let toExpr = Widgets.tryGetNodeFromWidget widget ToExpr |> ValueOption.toOption
 
             Expr.IndexRange(ExprIndexRangeNode(fromExpr, SingleTextNode.Create(".."), toExpr, Range.Zero)))
 

--- a/src/Fabulous.AST/Widgets/Expressions/InheritRecord.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/InheritRecord.fs
@@ -36,7 +36,7 @@ module InheritRecordBuilders =
             WidgetBuilder<Expr>(
                 InheritRecord.WidgetKey,
                 AttributesBundle(
-                    StackList.one(InheritRecord.Fields.WithValue(fields |> Seq.map Gen.mkOak)),
+                    StackList.one(InheritRecord.Fields.WithValue(fields |> Seq.map Gen.mkOak |> Seq.toArray)),
                     [| InheritRecord.InheritConstructor.WithValue(value.Compile()) |],
                     Array.empty
                 )

--- a/src/Fabulous.AST/Widgets/Expressions/Lambda.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Lambda.fs
@@ -21,7 +21,7 @@ module LambdaBuilders =
     type Ast with
 
         static member LambdaExpr(parameters: WidgetBuilder<Pattern> seq, value: WidgetBuilder<Expr>) =
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 Lambda.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/LibraryOnlyStaticOptimization.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/LibraryOnlyStaticOptimization.fs
@@ -33,7 +33,7 @@ module LibraryOnlyStaticOptimizationBuilders =
                 constraints: WidgetBuilder<StaticOptimizationConstraint> seq,
                 expr: WidgetBuilder<Expr>
             ) =
-            let constraints = constraints |> Seq.map Gen.mkOak
+            let constraints = constraints |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 LibraryOnlyStaticOptimization.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/Match.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Match.fs
@@ -28,7 +28,7 @@ module MatchBuilders =
             WidgetBuilder<Expr>(
                 Match.WidgetKey,
                 AttributesBundle(
-                    StackList.one(Match.MatchClauses.WithValue(clauses |> Seq.map Gen.mkOak)),
+                    StackList.one(Match.MatchClauses.WithValue(clauses |> Seq.map Gen.mkOak |> Seq.toArray)),
                     [| Match.MatchExpr.WithValue(value.Compile()) |],
                     Array.empty
                 )

--- a/src/Fabulous.AST/Widgets/Expressions/MatchLambda.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/MatchLambda.fs
@@ -18,7 +18,7 @@ module MatchLambdaBuilders =
     type Ast with
 
         static member MatchLambdaExpr(clauses: WidgetBuilder<MatchClauseNode> seq) =
-            let clauses = clauses |> Seq.map Gen.mkOak
+            let clauses = clauses |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(MatchLambda.WidgetKey, MatchLambda.Clauses.WithValue(clauses))
 

--- a/src/Fabulous.AST/Widgets/Expressions/ParenLambda.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/ParenLambda.fs
@@ -29,7 +29,7 @@ module ParenLambdaBuilders =
     type Ast with
 
         static member ParenLambdaExpr(parameters: WidgetBuilder<Pattern> seq, value: WidgetBuilder<Expr>) =
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 ParenLambda.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/Record.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Record.fs
@@ -50,7 +50,7 @@ module RecordExprBuilders =
                     StackList.three(
                         RecordExpr.OpenBrace.WithValue(leftSingleNode),
                         RecordExpr.CloseBrace.WithValue(rightSingleNode),
-                        RecordExpr.Fields.WithValue(fields |> Seq.map Gen.mkOak)
+                        RecordExpr.Fields.WithValue(fields |> Seq.map Gen.mkOak |> Seq.toArray)
                     ),
                     copyInfo,
                     Array.empty

--- a/src/Fabulous.AST/Widgets/Expressions/StructTuple.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/StructTuple.fs
@@ -30,7 +30,7 @@ module StructTupleBuilders =
     type Ast with
 
         static member StructTupleExpr(value: WidgetBuilder<Expr> seq) =
-            let parameters = value |> Seq.map Gen.mkOak
+            let parameters = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(StructTuple.WidgetKey, StructTuple.Items.WithValue(parameters))
 

--- a/src/Fabulous.AST/Widgets/Expressions/TryWith.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/TryWith.fs
@@ -40,7 +40,7 @@ module TryWithBuilders =
         /// }
         /// </code>
         static member TryWithExpr(value: WidgetBuilder<Expr>, clauses: WidgetBuilder<MatchClauseNode> seq) =
-            let clauses = clauses |> Seq.map Gen.mkOak
+            let clauses = clauses |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 TryWith.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Expressions/Tuple.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/Tuple.fs
@@ -23,7 +23,7 @@ module TupleBuilders =
     type Ast with
 
         static member TupleExpr(value: WidgetBuilder<Expr> seq) =
-            let parameters = value |> Seq.map Gen.mkOak
+            let parameters = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(Tuple.WidgetKey, Tuple.Items.WithValue(parameters))
 

--- a/src/Fabulous.AST/Widgets/Expressions/TypeApp.fs
+++ b/src/Fabulous.AST/Widgets/Expressions/TypeApp.fs
@@ -30,7 +30,7 @@ module TypeAppBuilders =
     type Ast with
 
         static member TypeAppExpr(value: WidgetBuilder<Expr>, parameters: WidgetBuilder<Type> seq) =
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Expr>(
                 TypeApp.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Measure.fs
+++ b/src/Fabulous.AST/Widgets/Measure.fs
@@ -304,7 +304,7 @@ module MeasureBuilders =
         /// <summary>Creates a sequence of measures.</summary>
         /// <param name="value">The seq of measures.</param>
         static member MeasureSeq(value: WidgetBuilder<Measure> seq) =
-            let measures = value |> Seq.map Gen.mkOak
+            let measures = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Measure>(Measure.WidgetSequenceKey, Measure.Measures.WithValue(measures))
 

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/BindingList.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/BindingList.fs
@@ -36,7 +36,7 @@ module LetBindingMemberBuilders =
         static member LetBindings(bindings: WidgetBuilder<BindingNode> seq) =
             WidgetBuilder<MemberDefn>(
                 BindingList.WidgetKey,
-                BindingList.Bindings.WithValue(bindings |> Seq.map Gen.mkOak)
+                BindingList.Bindings.WithValue(bindings |> Seq.map Gen.mkOak |> Seq.toArray)
             )
 
         /// <summary>

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Default.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Default.fs
@@ -28,14 +28,12 @@ module DefaultMember =
                 | Unknown -> None
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget MemberDefn.XmlDocs
-                |> ValueOption.map(fun x -> Some(x))
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget MemberDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MemberDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let isInlined =
                 Widgets.tryGetScalarValue widget BindingNode.IsInlined
@@ -50,8 +48,7 @@ module DefaultMember =
 
             let typeParams =
                 Widgets.tryGetNodeFromWidget widget MemberDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                |> ValueOption.toOption
 
             let node =
                 BindingNode(

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/ExternBinding.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/ExternBinding.fs
@@ -92,7 +92,7 @@ module ExternBindingNodeBuilders =
         static member ExternBinding
             (tp: WidgetBuilder<Type>, name: string, parameters: WidgetBuilder<ExternBindingPatternNode> seq)
             =
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<ExternBindingNode>(
                 ExternBinding.WidgetKey,
@@ -255,7 +255,7 @@ type ExternBindingNodeModifiers =
     static member inline attributes
         (this: WidgetBuilder<ExternBindingNode>, attributes: WidgetBuilder<AttributeNode> seq)
         =
-        this.AddScalar(ExternBinding.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(ExternBinding.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>
     /// Sets the attribute for the current widget.
@@ -364,5 +364,5 @@ type ExternBindingNodeYieldExtensions =
     static member inline YieldFrom
         (this: CollectionBuilder<'parent, ModuleDecl>, x: WidgetBuilder<ExternBindingNode> seq)
         : CollectionContent =
-        let nodes = x |> Seq.map Gen.mkOak
+        let nodes = x |> Seq.map Gen.mkOak |> Seq.toArray
         ExternBindingNodeYieldExtensions.YieldFrom(this, nodes)

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Field.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Field.fs
@@ -315,7 +315,7 @@ type FieldModifiers =
     /// </code>
     [<Extension>]
     static member inline attributes(this: WidgetBuilder<FieldNode>, attributes: WidgetBuilder<AttributeNode> seq) =
-        this.AddScalar(Field.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(Field.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>Sets the attributes for the current measure ValField definition.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Function.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Function.fs
@@ -35,14 +35,12 @@ module BindingFunction =
                 | Unknown -> None
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget BindingNode.XmlDocs
-                |> ValueOption.map(fun x -> Some(x))
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget BindingNode.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget BindingNode.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let isInlined =
                 Widgets.tryGetScalarValue widget BindingNode.IsInlined
@@ -57,8 +55,7 @@ module BindingFunction =
 
             let typeParams =
                 Widgets.tryGetNodeFromWidget widget BindingNode.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                |> ValueOption.toOption
 
             BindingNode(
                 xmlDocs,
@@ -87,7 +84,7 @@ module BindingFunctionBuilders =
                 ?returnType: WidgetBuilder<Type>
             ) =
             let name = PrettyNaming.NormalizeIdentifierBackticks name
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<BindingNode>(
                 BindingFunction.WidgetKey,

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/InterfaceMember.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/InterfaceMember.fs
@@ -104,5 +104,5 @@ type InterfaceMemberYieldExtensions =
     static member inline YieldFrom
         (this: CollectionBuilder<MemberDefn, MemberDefn>, xs: WidgetBuilder<BindingNode> seq)
         : CollectionContent =
-        let nodes = xs |> Seq.map Gen.mkOak
+        let nodes = xs |> Seq.map Gen.mkOak |> Seq.toArray
         InterfaceMemberYieldExtensions.YieldFrom(this, nodes)

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/MemberDefn.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/MemberDefn.fs
@@ -122,7 +122,7 @@ type ModuleDeclAttributeCollectionBuilderExtensions =
     static member inline YieldFrom
         (this: AttributeCollectionBuilder<'parent, MemberDefn>, xs: WidgetBuilder<MemberDefn> seq)
         : CollectionContent =
-        let nodes = xs |> Seq.map Gen.mkOak
+        let nodes = xs |> Seq.map Gen.mkOak |> Seq.toArray
         ModuleDeclAttributeCollectionBuilderExtensions.YieldFrom(this, nodes)
 
     [<Extension>]

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Method.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Method.fs
@@ -91,7 +91,7 @@ module BindingMethodBuilders =
                 body: WidgetBuilder<Expr>,
                 ?returnType: WidgetBuilder<Type>
             ) =
-            let parameters = parameters |> Seq.map Gen.mkOak
+            let parameters = parameters |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<MemberDefn>(
                 BindingMethodNode.WidgetKey,

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Property.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Property.fs
@@ -21,8 +21,8 @@ module BindingProperty =
 
             let returnType =
                 Widgets.tryGetNodeFromWidget widget BindingNode.Return
-                |> ValueOption.map(fun value -> Some(BindingReturnInfoNode(SingleTextNode.colon, value, Range.Zero)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map(fun value -> BindingReturnInfoNode(SingleTextNode.colon, value, Range.Zero))
+                |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget MemberDefn.Accessibility
@@ -36,14 +36,12 @@ module BindingProperty =
                 | Unknown -> None
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget MemberDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget MemberDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MemberDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let inlineNode =
                 match isInlined with
@@ -53,8 +51,7 @@ module BindingProperty =
 
             let typeParams =
                 Widgets.tryGetNodeFromWidget widget MemberDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                |> ValueOption.toOption
 
             let multipleTextsNode =
                 [ if isStatic then

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/PropertyGetSetBinding.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/PropertyGetSetBinding.fs
@@ -31,9 +31,9 @@ module PropertyGetSetBinding =
                 |> ValueOption.defaultValue AccessControl.Unknown
 
             let inlined =
-                Widgets.tryGetScalarValue widget IsInlined
-                |> ValueOption.map(fun x -> if x then Some SingleTextNode.``inline`` else None)
-                |> ValueOption.defaultValue None
+                match Widgets.tryGetScalarValue widget IsInlined with
+                | ValueSome true -> Some SingleTextNode.``inline``
+                | _ -> None
 
             let accessControl =
                 match accessControl with
@@ -61,8 +61,8 @@ module PropertyGetSetBinding =
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             PropertyGetSetBindingNode(
                 inlined,

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Value.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Value.fs
@@ -29,14 +29,12 @@ module BindingValue =
                 | Unknown -> None
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget BindingNode.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget BindingNode.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget BindingNode.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let isMutable =
                 Widgets.tryGetScalarValue widget BindingNode.IsMutable
@@ -48,13 +46,12 @@ module BindingValue =
 
             let returnType =
                 Widgets.tryGetNodeFromWidget widget BindingNode.Return
-                |> ValueOption.map(fun x -> Some(BindingReturnInfoNode(SingleTextNode.colon, x, Range.Zero)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map(fun x -> BindingReturnInfoNode(SingleTextNode.colon, x, Range.Zero))
+                |> ValueOption.toOption
 
             let typeParams =
                 Widgets.tryGetNodeFromWidget widget BindingNode.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                |> ValueOption.toOption
 
             BindingNode(
                 xmlDocs,

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/_BindingNode.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/_BindingNode.fs
@@ -70,7 +70,7 @@ type BindingNodeModifiers =
     /// </code>
     [<Extension>]
     static member inline attributes(this: WidgetBuilder<BindingNode>, attributes: WidgetBuilder<AttributeNode> seq) =
-        this.AddScalar(BindingNode.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(BindingNode.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>
     /// Sets the attributes for the current widget.

--- a/src/Fabulous.AST/Widgets/ModuleDeclarations/Exception.fs
+++ b/src/Fabulous.AST/Widgets/ModuleDeclarations/Exception.fs
@@ -15,14 +15,12 @@ module ExceptionDefn =
         Widgets.register "ExceptionDefn" (fun widget ->
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget ModuleDecl.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget ModuleDecl.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget ModuleDecl.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget ModuleDecl.Accessibility

--- a/src/Fabulous.AST/Widgets/ModuleDeclarations/ModuleDecl.fs
+++ b/src/Fabulous.AST/Widgets/ModuleDeclarations/ModuleDecl.fs
@@ -45,7 +45,7 @@ type ModuleDeclModifiers =
     /// <param name="attributes">The attributes to set.</param>
     [<Extension>]
     static member inline attributes(this: WidgetBuilder<ModuleDecl>, attributes: WidgetBuilder<AttributeNode> seq) =
-        this.AddScalar(ModuleDecl.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(ModuleDecl.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>Sets the attribute for the current module declaration widget.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.AST/Widgets/ModuleDeclarations/ModuleDeclAttributes.fs
+++ b/src/Fabulous.AST/Widgets/ModuleDeclarations/ModuleDeclAttributes.fs
@@ -13,8 +13,8 @@ module ModuleDeclAttributes =
 
             let attributes =
                 Widgets.tryGetScalarValue widget ModuleDecl.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let node = ModuleDeclAttributesNode(attributes, doExpression, Range.Zero)
             ModuleDecl.Attributes(node))

--- a/src/Fabulous.AST/Widgets/ModuleDeclarations/NestedModule.fs
+++ b/src/Fabulous.AST/Widgets/ModuleDeclarations/NestedModule.fs
@@ -35,14 +35,12 @@ module NestedModule =
                 | Unknown -> None
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget ModuleDecl.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget ModuleDecl.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget ModuleDecl.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let node =
                 NestedModuleNode(

--- a/src/Fabulous.AST/Widgets/ModuleDeclarations/Val.fs
+++ b/src/Fabulous.AST/Widgets/ModuleDeclarations/Val.fs
@@ -30,19 +30,17 @@ module Val =
     let WidgetKey =
         Widgets.register "ValNode" (fun widget ->
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget<XmlDocNode> widget XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget<XmlDocNode> widget XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let inlined =
                 Widgets.tryGetScalarValue widget IsInlined
-                |> ValueOption.map(fun _ -> Some(SingleTextNode.``inline``))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map(fun _ -> SingleTextNode.``inline``)
+                |> ValueOption.toOption
 
             let isMutable =
                 Widgets.tryGetScalarValue widget IsMutable |> ValueOption.defaultValue(false)
@@ -64,16 +62,14 @@ module Val =
                 | Unknown -> None
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeParams |> ValueOption.toOption
 
             let leadingKeyword =
                 Widgets.tryGetScalarValue widget LeadingKeyword
                 |> ValueOption.map(List.ofSeq)
                 |> ValueOption.filter(_.IsEmpty >> not)
-                |> ValueOption.map(fun nodes -> Some(MultipleTextsNode(nodes, Range.Zero)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map(fun nodes -> MultipleTextsNode(nodes, Range.Zero))
+                |> ValueOption.toOption
 
             ValNode(
                 xmlDocs,
@@ -263,7 +259,7 @@ type ValNodeModifiers =
     /// </code>
     [<Extension>]
     static member inline attributes(this: WidgetBuilder<ValNode>, attributes: WidgetBuilder<AttributeNode> seq) =
-        this.AddScalar(Val.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(Val.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>Sets the attribute for the current Val.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.AST/Widgets/ModuleOrNamespace.fs
+++ b/src/Fabulous.AST/Widgets/ModuleOrNamespace.fs
@@ -63,15 +63,12 @@ module ModuleOrNamespace =
                     | Internal -> Some(SingleTextNode.``internal``)
                     | Unknown -> None
 
-                let xmlDocs =
-                    Widgets.tryGetNodeFromWidget widget XmlDocs
-                    |> ValueOption.map(fun x -> Some(x))
-                    |> ValueOption.defaultValue None
+                let xmlDocs = Widgets.tryGetNodeFromWidget widget XmlDocs |> ValueOption.toOption
 
                 let attributes =
                     Widgets.tryGetScalarValue widget MultipleAttributes
-                    |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                    |> ValueOption.defaultValue None
+                    |> ValueOption.map MultipleAttributeListNode.Create
+                    |> ValueOption.toOption
 
                 let header =
                     Some(
@@ -292,7 +289,7 @@ type NamespaceModifiers =
     static member inline attributes
         (this: WidgetBuilder<ModuleOrNamespaceNode>, attributes: WidgetBuilder<AttributeNode> seq)
         =
-        this.AddScalar(ModuleOrNamespace.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(ModuleOrNamespace.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray))
 
     /// <summary>Sets the attributes for the current namespace.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.AST/Widgets/Patterns/Ands.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/Ands.fs
@@ -17,7 +17,7 @@ module AndsBuilders =
     type Ast with
 
         static member AndsPat(values: WidgetBuilder<Pattern> seq) =
-            WidgetBuilder<Pattern>(Ands.WidgetKey, Ands.Items.WithValue(values |> Seq.map Gen.mkOak))
+            WidgetBuilder<Pattern>(Ands.WidgetKey, Ands.Items.WithValue(values |> Seq.map Gen.mkOak |> Seq.toArray))
 
         static member AndsPat(values: WidgetBuilder<Constant> seq) =
             let values = values |> Seq.map Ast.ConstantPat

--- a/src/Fabulous.AST/Widgets/Patterns/ArrayOrList.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/ArrayOrList.fs
@@ -27,7 +27,7 @@ module ArrayOrListPatBuilders =
         static member ListPat(values: WidgetBuilder<Pattern> seq) =
             WidgetBuilder<Pattern>(
                 ArrayOrListPat.WidgetKey,
-                ArrayOrListPat.Parameters.WithValue(values |> Seq.map Gen.mkOak),
+                ArrayOrListPat.Parameters.WithValue(values |> Seq.map Gen.mkOak |> Seq.toArray),
                 ArrayOrListPat.OpenTextNode.WithValue(SingleTextNode.leftBracket),
                 ArrayOrListPat.CloseTextNode.WithValue(SingleTextNode.rightBracket)
             )
@@ -41,7 +41,7 @@ module ArrayOrListPatBuilders =
         static member ArrayPat(values: WidgetBuilder<Pattern> seq) =
             WidgetBuilder<Pattern>(
                 ArrayOrListPat.WidgetKey,
-                ArrayOrListPat.Parameters.WithValue(values |> Seq.map Gen.mkOak),
+                ArrayOrListPat.Parameters.WithValue(values |> Seq.map Gen.mkOak |> Seq.toArray),
                 ArrayOrListPat.OpenTextNode.WithValue(SingleTextNode.leftArray),
                 ArrayOrListPat.CloseTextNode.WithValue(SingleTextNode.rightArray)
             )

--- a/src/Fabulous.AST/Widgets/Patterns/ExternBindingPattern.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/ExternBindingPattern.fs
@@ -16,20 +16,14 @@ module ExternBindingPattern =
 
     let WidgetKey =
         Widgets.register "ExternBindingPattern" (fun widget ->
-            let pat =
-                Widgets.tryGetNodeFromWidget widget PatternVal
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+            let pat = Widgets.tryGetNodeFromWidget widget PatternVal |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
-            let tp =
-                Widgets.tryGetNodeFromWidget widget TypeValue
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+            let tp = Widgets.tryGetNodeFromWidget widget TypeValue |> ValueOption.toOption
 
             ExternBindingPatternNode(attributes, tp, pat, Range.Zero))
 
@@ -64,7 +58,9 @@ type ExternBindingPatternNodeModifiers =
     static member inline attributes
         (this: WidgetBuilder<ExternBindingPatternNode>, attributes: WidgetBuilder<AttributeNode> seq)
         =
-        this.AddScalar(ExternBindingPattern.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak))
+        this.AddScalar(
+            ExternBindingPattern.MultipleAttributes.WithValue(attributes |> Seq.map Gen.mkOak |> Seq.toArray)
+        )
 
     [<Extension>]
     static member inline attribute

--- a/src/Fabulous.AST/Widgets/Patterns/ImplicitConstructor.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/ImplicitConstructor.fs
@@ -21,15 +21,12 @@ module ImplicitConstructor =
 
     let WidgetKey =
         Widgets.register "ImplicitConstructor" (fun widget ->
-            let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let xmlDocs = Widgets.tryGetNodeFromWidget widget XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let pattern = Widgets.getNodeFromWidget<Pattern> widget Pattern
 

--- a/src/Fabulous.AST/Widgets/Patterns/LongIdent.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/LongIdent.fs
@@ -64,7 +64,7 @@ module LongIdentPatternBuilders =
         static member LongIdentPat(pairs: WidgetBuilder<Pattern> seq) =
             WidgetBuilder<Pattern>(
                 LongIdentPattern.WidgetKey,
-                LongIdentPattern.Pairs.WithValue(pairs |> Seq.map Gen.mkOak)
+                LongIdentPattern.Pairs.WithValue(pairs |> Seq.map Gen.mkOak |> Seq.toArray)
             )
 
         static member LongIdentPat(pair: WidgetBuilder<Pattern>) = Ast.LongIdentPat([ pair ])
@@ -85,7 +85,7 @@ module LongIdentPatternBuilders =
                 AttributesBundle(
                     StackList.two(
                         LongIdentPattern.Identifiers.WithValue(ident),
-                        LongIdentPattern.Pairs.WithValue(pairs |> Seq.map Gen.mkOak)
+                        LongIdentPattern.Pairs.WithValue(pairs |> Seq.map Gen.mkOak |> Seq.toArray)
                     ),
                     Array.empty,
                     Array.empty

--- a/src/Fabulous.AST/Widgets/Patterns/NamePatPairs.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/NamePatPairs.fs
@@ -52,6 +52,6 @@ module NamePatPairsBuilders =
         static member NamePatPairsPat(ident: string, pairs: WidgetBuilder<NamePatPair> seq) =
             WidgetBuilder<Pattern>(
                 NamePatPairs.WidgetKey,
-                NamePatPairs.Pairs.WithValue(pairs |> Seq.map Gen.mkOak),
+                NamePatPairs.Pairs.WithValue(pairs |> Seq.map Gen.mkOak |> Seq.toArray),
                 NamePatPairs.Identifiers.WithValue(ident)
             )

--- a/src/Fabulous.AST/Widgets/Patterns/Parameter.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/Parameter.fs
@@ -13,15 +13,12 @@ module Parameter =
         Widgets.register "Parameter" (fun widget ->
             let value = Widgets.getNodeFromWidget<Pattern> widget Value
 
-            let typeValue =
-                Widgets.tryGetNodeFromWidget widget TypeVal
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let typeValue = Widgets.tryGetNodeFromWidget widget TypeVal |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget Pattern.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             Pattern.Parameter(PatParameterNode(attributes, value, typeValue, Range.Zero)))
 

--- a/src/Fabulous.AST/Widgets/Patterns/Record.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/Record.fs
@@ -20,4 +20,7 @@ module RecordPatBuilders =
     type Ast with
 
         static member RecordPat(fields: WidgetBuilder<PatRecordField> seq) =
-            WidgetBuilder<Pattern>(RecordPat.WidgetKey, RecordPat.Fields.WithValue(fields |> Seq.map Gen.mkOak))
+            WidgetBuilder<Pattern>(
+                RecordPat.WidgetKey,
+                RecordPat.Fields.WithValue(fields |> Seq.map Gen.mkOak |> Seq.toArray)
+            )

--- a/src/Fabulous.AST/Widgets/Patterns/RecordField.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/RecordField.fs
@@ -26,8 +26,8 @@ module RecordFieldPat =
                 Widgets.tryGetScalarValue widget Prefix
                 |> ValueOption.map(fun value ->
                     let value = PrettyNaming.NormalizeIdentifierBackticks value
-                    Some(IdentListNode([ IdentifierOrDot.Ident(SingleTextNode.Create(value)) ], Range.Zero)))
-                |> ValueOption.defaultValue None
+                    IdentListNode([ IdentifierOrDot.Ident(SingleTextNode.Create(value)) ], Range.Zero))
+                |> ValueOption.toOption
 
             PatRecordField(prefix, SingleTextNode.Create(fieldName), SingleTextNode.equals, pattern, Range.Zero))
 

--- a/src/Fabulous.AST/Widgets/Patterns/StructTuple.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/StructTuple.fs
@@ -20,7 +20,7 @@ module StructTuplePatBuilders =
         static member StructTuplePat(values: WidgetBuilder<Pattern> seq) =
             WidgetBuilder<Pattern>(
                 StructTuplePat.WidgetKey,
-                StructTuplePat.Parameters.WithValue(values |> Seq.map Gen.mkOak)
+                StructTuplePat.Parameters.WithValue(values |> Seq.map Gen.mkOak |> Seq.toArray)
             )
 
         static member StructTuplePat(values: WidgetBuilder<Constant> seq) =

--- a/src/Fabulous.AST/Widgets/Patterns/Tuple.fs
+++ b/src/Fabulous.AST/Widgets/Patterns/Tuple.fs
@@ -23,7 +23,7 @@ module TuplePatBuilders =
     type Ast with
 
         static member TuplePat(value: WidgetBuilder<Pattern> seq) =
-            let parameters = value |> Seq.map Gen.mkOak
+            let parameters = value |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Pattern>(TuplePat.WidgetKey, TuplePat.Parameters.WithValue(parameters))
 

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Abbrev.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Abbrev.fs
@@ -19,21 +19,17 @@ module TypeDefnAbbrevNode =
             let name = Widgets.getScalarValue widget Name
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let aliasType = Widgets.getNodeFromWidget widget AliasType
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             TypeDefn.Abbrev(
                 TypeDefnAbbrevNode(

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Augment.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Augment.fs
@@ -22,18 +22,14 @@ module Augmentation =
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(fun x -> Some(x))
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget TypeDefn.Accessibility

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Delegate.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Delegate.fs
@@ -35,14 +35,12 @@ module Delegate =
                         (t, SingleTextNode.star))
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget TypeDefn.Accessibility
@@ -92,7 +90,7 @@ module DelegateBuilders =
                 AttributesBundle(
                     StackList.two(
                         Delegate.Name.WithValue(name),
-                        Delegate.Parameters.WithValue(parameters |> Seq.map Gen.mkOak)
+                        Delegate.Parameters.WithValue(parameters |> Seq.map Gen.mkOak |> Seq.toArray)
                     ),
                     [| Delegate.Return.WithValue(returnType.Compile()) |],
                     Array.empty

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Enum.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Enum.fs
@@ -22,14 +22,12 @@ module Enum =
                 Widgets.getNodesFromWidgetCollection<EnumCaseNode> widget EnumCaseNode
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             TypeDefn.Enum(
                 TypeDefnEnumNode(

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/EnumCase.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/EnumCase.fs
@@ -26,15 +26,12 @@ module EnumCase =
 
             let value = Widgets.getNodeFromWidget widget Value
 
-            let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let xmlDocs = Widgets.tryGetNodeFromWidget widget XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             EnumCaseNode(
                 xmlDocs,

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Measure.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Measure.fs
@@ -20,16 +20,13 @@ module TypeNameNode =
             let name = Widgets.getScalarValue widget Name
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let measureAttribute = Widgets.getScalarValue widget MeasureAttribute |> List.ofSeq
 
             let multipleAttributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                |> ValueOption.toOption
 
             let attributes =
                 match multipleAttributes with

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
@@ -25,19 +25,15 @@ module Record =
                 |> ValueOption.defaultValue []
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget TypeDefn.Accessibility

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnExplicit.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnExplicit.fs
@@ -22,18 +22,14 @@ module TypeDefnExplicit =
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let implicitConstructor =
                 Widgets.tryGetNodeFromWidget<ImplicitConstructorNode> widget Constructor

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnRegular.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnRegular.fs
@@ -26,19 +26,15 @@ module TypeDefnRegular =
                 |> ValueOption.defaultValue []
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let constructor =
                 match constructor with

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Union.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Union.fs
@@ -26,19 +26,15 @@ module Union =
                 |> ValueOption.defaultValue []
 
             let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.XmlDocs |> ValueOption.toOption
 
             let attributes =
                 Widgets.tryGetScalarValue widget TypeDefn.MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let typeParams =
-                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams
-                |> ValueOption.map Some
-                |> ValueOption.defaultValue None
+                Widgets.tryGetNodeFromWidget widget TypeDefn.TypeParams |> ValueOption.toOption
 
             let accessControl =
                 Widgets.tryGetScalarValue widget TypeDefn.Accessibility

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/UnionCase.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/UnionCase.fs
@@ -34,13 +34,10 @@ module UnionCase =
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
-            let xmlDocs =
-                Widgets.tryGetNodeFromWidget widget XmlDocs
-                |> ValueOption.map(Some)
-                |> ValueOption.defaultValue None
+            let xmlDocs = Widgets.tryGetNodeFromWidget widget XmlDocs |> ValueOption.toOption
 
             UnionCaseNode(xmlDocs, attributes, None, name, fields, Range.Zero))
 
@@ -82,7 +79,7 @@ module UnionCaseBuilders =
                 AttributesBundle(
                     StackList.two(
                         UnionCase.Name.WithValue(name),
-                        UnionCase.Fields.WithValue(fields |> Seq.map Gen.mkOak)
+                        UnionCase.Fields.WithValue(fields |> Seq.map Gen.mkOak |> Seq.toArray)
                     ),
                     Array.empty,
                     Array.empty
@@ -296,5 +293,5 @@ type UnionCaseYieldExtensions =
     static member inline YieldFrom
         (this: CollectionBuilder<TypeDefnUnionNode, UnionCaseNode>, x: WidgetBuilder<UnionCaseNode> seq)
         : CollectionContent =
-        let nodes = x |> Seq.map Gen.mkOak
+        let nodes = x |> Seq.map Gen.mkOak |> Seq.toArray
         UnionCaseYieldExtensions.YieldFrom(this, nodes)

--- a/src/Fabulous.AST/Widgets/Types/AppPrefix.fs
+++ b/src/Fabulous.AST/Widgets/Types/AppPrefix.fs
@@ -45,7 +45,7 @@ module TypeAppPrefix =
 module TypeAppPrefixBuilders =
     type Ast with
         static member AppPrefix(t: WidgetBuilder<Type>, arguments: WidgetBuilder<Type> seq) =
-            let arguments = arguments |> Seq.map Gen.mkOak
+            let arguments = arguments |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(
                 TypeAppPrefix.WidgetKey,
@@ -78,7 +78,7 @@ module TypeAppPrefixBuilders =
         static member AppPrefix
             (t: WidgetBuilder<Type>, postIdentifier: string seq, arguments: WidgetBuilder<Type> seq)
             =
-            let arguments = arguments |> Seq.map Gen.mkOak
+            let arguments = arguments |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(
                 TypeAppPrefix.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Types/Funs.fs
+++ b/src/Fabulous.AST/Widgets/Types/Funs.fs
@@ -30,7 +30,7 @@ module FunsBuilders =
             WidgetBuilder<Type>(
                 TypeFuns.WidgetKey,
                 AttributesBundle(
-                    StackList.one(TypeFuns.Parameters.WithValue(parameters |> Seq.map Gen.mkOak)),
+                    StackList.one(TypeFuns.Parameters.WithValue(parameters |> Seq.map Gen.mkOak |> Seq.toArray)),
                     [| TypeFuns.Return.WithValue(returnType.Compile()) |],
                     Array.empty
                 )

--- a/src/Fabulous.AST/Widgets/Types/Intersection.fs
+++ b/src/Fabulous.AST/Widgets/Types/Intersection.fs
@@ -24,7 +24,7 @@ module Intersection =
 module IntersectionBuilders =
     type Ast with
         static member Intersection(values: WidgetBuilder<Type> seq) =
-            let values = values |> Seq.map Gen.mkOak
+            let values = values |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(Intersection.WidgetKey, Intersection.Values.WithValue(values))
 

--- a/src/Fabulous.AST/Widgets/Types/SignatureParameter.fs
+++ b/src/Fabulous.AST/Widgets/Types/SignatureParameter.fs
@@ -18,15 +18,15 @@ module SignatureParameter =
         Widgets.register "SignatureParameter" (fun widget ->
             let identifier =
                 Widgets.tryGetScalarValue widget Identifier
-                |> ValueOption.map(fun x -> Some(SingleTextNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map SingleTextNode.Create
+                |> ValueOption.toOption
 
             let value = Widgets.getNodeFromWidget<Type> widget TypedValue
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             Type.SignatureParameter(TypeSignatureParameterNode(attributes, identifier, value, Range.Zero)))
 

--- a/src/Fabulous.AST/Widgets/Types/StructTuple.fs
+++ b/src/Fabulous.AST/Widgets/Types/StructTuple.fs
@@ -24,7 +24,10 @@ module TypeStructTuple =
 module TypeStructTupleBuilders =
     type Ast with
         static member StructTuple(items: WidgetBuilder<Type> seq) =
-            WidgetBuilder<Type>(TypeStructTuple.WidgetKey, TypeStructTuple.Items.WithValue(items |> Seq.map Gen.mkOak))
+            WidgetBuilder<Type>(
+                TypeStructTuple.WidgetKey,
+                TypeStructTuple.Items.WithValue(items |> Seq.map Gen.mkOak |> Seq.toArray)
+            )
 
         static member StructTuple(items: string seq) =
             let items = items |> Seq.map Ast.LongIdent

--- a/src/Fabulous.AST/Widgets/Types/Tuple.fs
+++ b/src/Fabulous.AST/Widgets/Types/Tuple.fs
@@ -27,12 +27,12 @@ module TypeTuple =
 module TypeTupleBuilders =
     type Ast with
         static member Tuple(items: WidgetBuilder<Type> seq) =
-            let items = items |> Seq.map Gen.mkOak
+            let items = items |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(TypeTuple.WidgetKey, TypeTuple.Items.WithValue(items))
 
         static member Tuple(items: WidgetBuilder<Type> seq, exponent: string) =
-            let items = items |> Seq.map Gen.mkOak
+            let items = items |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(
                 TypeTuple.WidgetKey,

--- a/src/Fabulous.AST/Widgets/Types/TyparDecls.fs
+++ b/src/Fabulous.AST/Widgets/Types/TyparDecls.fs
@@ -22,8 +22,8 @@ module TyparDeclNode =
 
             let attributes =
                 Widgets.tryGetScalarValue widget MultipleAttributes
-                |> ValueOption.map(fun x -> Some(MultipleAttributeListNode.Create(x)))
-                |> ValueOption.defaultValue None
+                |> ValueOption.map MultipleAttributeListNode.Create
+                |> ValueOption.toOption
 
             let intersectionConstrains =
                 Widgets.getScalarValue widget IntersectionConstrains
@@ -51,7 +51,7 @@ module TyparDeclNodeBuilders =
     type Ast with
 
         static member TyparDecl(tyPar: string, constraints: WidgetBuilder<Type> seq) =
-            let constrains = constraints |> Seq.map Gen.mkOak
+            let constrains = constraints |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<TyparDeclNode>(
                 TyparDeclNode.WidgetKey,
@@ -120,7 +120,7 @@ module TyparDeclsBuilders =
         static member SinglePrefix(value: string) = Ast.SinglePrefix(Ast.TyparDecl(value))
 
         static member PrefixList(decls: WidgetBuilder<TyparDeclNode> seq) =
-            let decls = decls |> Seq.map Gen.mkOak
+            let decls = decls |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<TyparDecls>(TyparDecls.WidgetPrefixListKey, TyparDecls.Decls.WithValue(decls))
 
@@ -135,8 +135,8 @@ module TyparDeclsBuilders =
         static member PostfixList
             (decls: WidgetBuilder<TyparDeclNode> seq, constraints: WidgetBuilder<TypeConstraint> seq)
             =
-            let decls = decls |> Seq.map Gen.mkOak
-            let constraints = constraints |> Seq.map Gen.mkOak
+            let decls = decls |> Seq.map Gen.mkOak |> Seq.toArray
+            let constraints = constraints |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<TyparDecls>(
                 TyparDecls.WidgetPostfixListKey,

--- a/src/Fabulous.AST/Widgets/Types/WithGlobalConstraints.fs
+++ b/src/Fabulous.AST/Widgets/Types/WithGlobalConstraints.fs
@@ -17,7 +17,7 @@ module WithGlobalConstraints =
 module WithGlobalConstraintsBuilders =
     type Ast with
         static member WithGlobal(tp: WidgetBuilder<Type>, constraints: WidgetBuilder<TypeConstraint> seq) =
-            let constraints = constraints |> Seq.map Gen.mkOak
+            let constraints = constraints |> Seq.map Gen.mkOak |> Seq.toArray
 
             WidgetBuilder<Type>(
                 WithGlobalConstraints.WidgetKey,


### PR DESCRIPTION
## Summary

Mechanical cleanup applying the two patterns established in #178 (and verified again in #179) to the rest of the `Widgets/` tree.

| Fix | Sites | Reason |
|---|---|---|
| Replace `ValueOption.map Some \|> defaultValue None` with `ValueOption.toOption` | ~46 across ~29 files | FSharp.Core 10.1.300 (pulled in by #178) exposes `ValueOption.toOption` natively; the verbose form was just legacy. Where the inner `Some(F x)` wrapped a constructor application, the lambda is flattened to `\|> ValueOption.map F \|> ValueOption.toOption`. |
| Materialize lazy `Seq.map Gen.mkOak` with `\|> Seq.toArray` | ~28 sites | Same lazy-seq footgun #178 fixed for `MemberDefnModifiers.attributes`: when a `Seq.map Gen.mkOak` result is stored in a widget attribute via `WithValue`, downstream consumers iterating it can hit re-evaluation / single-shot enumerable bugs. Materializing once at the boundary is cheap and removes the foot-gun. |

Two unusual voption sites needed bespoke rewrites:
- `PropertyGetSetBinding.fs:33-36` — was an `Option<Option<...>>` flatten via `map (fun x -> if x then Some... else None)` plus `defaultValue None`. Rewritten to a direct `match ValueSome true -> ... | _ -> None`.
- `Patterns/RecordField.fs:27-30` — multi-statement map body. Rewritten by removing the inner `Some` wrap and switching the outer `defaultValue None` to `toOption`.

## Scope

70 files changed, +181/-251 lines (net **-70 LOC**). No public API changes, no behavior changes for valid inputs — purely:
1. Idiomatic FSharp.Core 10 usage (`toOption` vs the manual `map Some |> defaultValue None`)
2. Defensive materialization of single-shot sequences

## Verification

- `dotnet fsi build.fsx` green: lint, build (net8.0/net10.0/netstandard2.1), tests, docs, pack
- `dotnet test`: 780/780 on both `net8.0` and `net10.0`
- `dotnet fantomas --check src docs extensions build.fsx`: clean

## How this was done

Most edits were applied with two `perl -i -0pe` substitutions (multi-line regex for the voption patterns, line-level for the `Seq.toArray` append), then a final `dotnet fantomas` pass over the touched files. A handful of irregular sites were handled by hand. Reviewer tip: the diff is dominated by repetitive 3-line→1-line collapses; each file's change should match the patterns above.

## Follow-up (out of scope)

- The duplicated `defaultArg ... false` / `defaultArg ... AccessControl.Unknown` boilerplate across builder overload sets (~8 overloads per widget × dozens of widgets) is still pervasive. That's a larger design refactor, not a mechanical sweep — best left for a separate PR.