### PR TITLE
test: specialized tests for complex code generation scenarios

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="xunit.v3" Version="3.2.1"/>
     <PackageVersion Include="Verify.XunitV3" Version="27.1.0" />
     <PackageVersion Include="FsCheck.Xunit" Version="2.16.6" />
+    <PackageVersion Include="FsCheck" Version="2.16.6" />
     <PackageVersion Include="FsUnit.xUnit" Version="6.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
     <!-- MSBuild task dependencies -->

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -134,10 +134,15 @@
         <Compile Include="Types\LongIdent.fs" />
         <Compile Include="Types\Measures.fs" />
         <Compile Include="Extensions\Json.fs" />
+        <Compile Include="Specialized\Composition.fs" />
+        <Compile Include="Specialized\FSharpFeatures.fs" />
+        <Compile Include="Specialized\RealWorld.fs" />
+        <Compile Include="Specialized\Properties.fs" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="FsCheck.Xunit" />
+        <PackageReference Include="FsCheck" />
         <PackageReference Include="FsUnit.xUnit" />
         <PackageReference Include="Verify.XunitV3" />
         <PackageReference Include="xunit.v3" />

--- a/src/Fabulous.AST.Tests/Specialized/Composition.fs
+++ b/src/Fabulous.AST.Tests/Specialized/Composition.fs
@@ -1,0 +1,241 @@
+namespace Fabulous.AST.Tests.Specialized
+
+open Fabulous.AST
+open Fabulous.AST.Tests
+open Xunit
+
+open type Ast
+
+/// Composition tests — exercise multiple widgets interacting in shapes that match
+/// real F# code, beyond the per-widget happy-path tests in the rest of the suite.
+module Composition =
+
+    [<Fact>]
+    let ``Interface with xmldocs, class with attributes, inheritance and interface impl``() =
+        Oak() {
+            AnonymousModule() {
+                (TypeDefn("IShape") {
+                    AbstractMember("Area", Float())
+                    AbstractMember("Perimeter", Float())
+                })
+                    .xmlDocs([ "Shape with measurable area and perimeter." ])
+
+                (TypeDefn("Shape", UnitPat()) {
+                    InterfaceWith("IShape") {
+                        Member("this.Area", ConstantExpr(Float 0.0))
+                        Member("this.Perimeter", ConstantExpr(Float 0.0))
+                    }
+                })
+                    .xmlDocs([ "Base shape with degenerate area / perimeter." ])
+                    .attributes([ Attribute("Sealed") ])
+
+                TypeDefn("Circle", ParenPat(ParameterPat("radius", Float()))) {
+                    Inherit("Shape()")
+
+                    InterfaceWith("IShape") {
+                        Member(
+                            "this.Area",
+                            InfixAppExpr(
+                                ConstantExpr(Constant "System.Math.PI"),
+                                "*",
+                                InfixAppExpr(ConstantExpr(Constant "radius"), "*", ConstantExpr(Constant "radius"))
+                            )
+                        )
+
+                        Member(
+                            "this.Perimeter",
+                            InfixAppExpr(
+                                InfixAppExpr(ConstantExpr(Float 2.0), "*", ConstantExpr(Constant "System.Math.PI")),
+                                "*",
+                                ConstantExpr(Constant "radius")
+                            )
+                        )
+                    }
+                }
+
+            }
+        }
+        |> produces
+            """
+/// Shape with measurable area and perimeter.
+type IShape =
+    abstract Area: float
+    abstract Perimeter: float
+
+/// Base shape with degenerate area / perimeter.
+[<Sealed>]
+type Shape() =
+    interface IShape with
+        member this.Area = 0.0
+        member this.Perimeter = 0.0
+
+type Circle(radius: float) =
+    inherit Shape()
+
+    interface IShape with
+        member this.Area = System.Math.PI * radius * radius
+        member this.Perimeter = 2.0 * System.Math.PI * radius
+"""
+
+    [<Fact>]
+    let ``Discriminated union with xmlDocs and a matching helper``() =
+        Oak() {
+            AnonymousModule() {
+                (Union("Result") {
+                    UnionCase("Ok", Field("value", "'T"))
+                    UnionCase("Error", Field("error", "'E"))
+                })
+                    .typeParams(PostfixList([ "'T"; "'E" ]))
+                    .xmlDocs([ "A computation that may fail with a typed error." ])
+
+                Function(
+                    "tryDivide",
+                    [ ParameterPat("x"); ParameterPat("y") ],
+                    IfThenElseExpr(
+                        InfixAppExpr(ConstantExpr(Constant "y"), "=", ConstantExpr(Int 0)),
+                        AppExpr(ConstantExpr(Constant "Error"), [ ConstantExpr(String "divide by zero") ]),
+                        AppExpr(
+                            ConstantExpr(Constant "Ok"),
+                            [ ParenExpr(InfixAppExpr(ConstantExpr(Constant "x"), "/", ConstantExpr(Constant "y"))) ]
+                        )
+                    )
+                )
+
+            }
+        }
+        |> produces
+            """
+/// A computation that may fail with a typed error.
+type Result<'T, 'E> =
+    | Ok of value: 'T
+    | Error of error: 'E
+
+let tryDivide x y =
+    if y = 0 then Error "divide by zero" else Ok (x / y)
+"""
+
+    [<Fact>]
+    let ``Record with computed member and interface implementation``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("IFormattable") { AbstractMember("Format", [ Unit() ], String()) }
+
+                (Record("Person") {
+                    Field("FirstName", String())
+                    Field("LastName", String())
+                    Field("Age", Int())
+                })
+                    .members() {
+                    Member(
+                        "this.FullName",
+                        InfixAppExpr(
+                            InfixAppExpr(ConstantExpr(Constant "this.FirstName"), "+", ConstantExpr(String " ")),
+                            "+",
+                            ConstantExpr(Constant "this.LastName")
+                        )
+                    )
+
+                    InterfaceWith(LongIdent "IFormattable") {
+                        Member(
+                            "this.Format",
+                            UnitPat(),
+                            AppExpr(
+                                ConstantExpr(Constant "sprintf"),
+                                [ ConstantExpr(String "%s (%d)")
+                                  ConstantExpr(Constant "this.FullName")
+                                  ConstantExpr(Constant "this.Age") ]
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        |> produces
+            """
+type IFormattable =
+    abstract Format: unit -> string
+
+type Person =
+    { FirstName: string
+      LastName: string
+      Age: int }
+
+    member this.FullName = this.FirstName + " " + this.LastName
+
+    interface IFormattable with
+        member this.Format() =
+            sprintf "%s (%d)" this.FullName this.Age
+"""
+
+    [<Fact>]
+    let ``Namespace with nested module containing abbrevs and functions``() =
+        Oak() {
+            Namespace("MyApp.Domain") {
+                Module("Money") {
+                    Abbrev("Cents", Int())
+                    Abbrev("Dollars", Float())
+
+                    Function(
+                        "toCents",
+                        [ ParameterPat("d") ],
+                        AppExpr(
+                            ConstantExpr(Constant "int"),
+                            [ ParenExpr(InfixAppExpr(ConstantExpr(Constant "d"), "*", ConstantExpr(Float 100.0))) ]
+                        )
+                    )
+
+                    Function(
+                        "toDollars",
+                        [ ParameterPat("c") ],
+                        InfixAppExpr(
+                            ParenExpr(AppExpr(ConstantExpr(Constant "float"), [ ConstantExpr(Constant "c") ])),
+                            "/",
+                            ConstantExpr(Float 100.0)
+                        )
+                    )
+                }
+            }
+        }
+        |> produces
+            """
+namespace MyApp.Domain
+
+module Money =
+    type Cents = int
+    type Dollars = float
+    let toCents d = int (d * 100.0)
+    let toDollars c = (float c) / 100.0
+"""
+
+    [<Fact>]
+    let ``Mutually recursive union types with `and` keyword``() =
+        Oak() {
+            AnonymousModule() {
+                (Union("Tree") {
+                    UnionCase("Leaf")
+                    UnionCase("Branch", Field("forest", LongIdent "Forest"))
+                })
+                    .typeParams(PostfixList([ "'a" ]))
+
+                (Union("Forest") {
+                    UnionCase("Empty")
+
+                    UnionCase(
+                        "NonEmpty",
+                        Field("trees", AppPrefix(LongIdent "list", [ AppPrefix(LongIdent "Tree", [ LongIdent "'a" ]) ]))
+                    )
+                })
+                    .typeParams(PostfixList([ "'a" ]))
+                |> _.toRecursive()
+            }
+        }
+        |> produces
+            """
+type Tree<'a> =
+    | Leaf
+    | Branch of forest: Forest
+
+and Forest<'a> =
+    | Empty
+    | NonEmpty of trees: list<Tree<'a>>
+"""

--- a/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
+++ b/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
@@ -108,6 +108,30 @@ let result =
 """
 
     [<Fact>]
+    let ``Type extension via Augmentation (type X with member ...)``() =
+        Oak() {
+            AnonymousModule() {
+                Augmentation("List") {
+                    Member(
+                        "this.Second",
+                        AppExpr(ConstantExpr(Constant "List.head"), [ ConstantExpr(Constant "this.Tail") ])
+                    )
+
+                    Member(
+                        "this.IsEmpty2",
+                        InfixAppExpr(ConstantExpr(Constant "List.length this"), "=", ConstantExpr(Int 0))
+                    )
+                }
+            }
+        }
+        |> produces
+            """
+type List with
+    member this.Second = List.head this.Tail
+    member this.IsEmpty2 = List.length this = 0
+"""
+
+    [<Fact>]
     let ``For-each loop over a list``() =
         Oak() {
             AnonymousModule() {

--- a/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
+++ b/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
@@ -1,0 +1,132 @@
+namespace Fabulous.AST.Tests.Specialized
+
+open Fabulous.AST
+open Fabulous.AST.Tests
+open Xunit
+
+open type Ast
+
+/// Targeted tests for F# 8/9/10 language features. These cover scenarios that the
+/// per-widget tests don't exercise but that real consumers expect to generate.
+module FSharpFeatures =
+
+    [<Fact>]
+    let ``Static abstract member on interface (IWSAM-style)``() =
+        Oak() { AnonymousModule() { TypeDefn("IShow") { AbstractMember("Show", [ Unit() ], String()).toStatic() } } }
+        |> produces
+            """
+type IShow =
+    static abstract Show: unit -> string
+"""
+
+    [<Fact>]
+    let ``Static abstract property on interface``() =
+        Oak() { AnonymousModule() { TypeDefn("IDefault") { AbstractMember("Default", Int()).toStatic() } } }
+        |> produces
+            """
+type IDefault =
+    static abstract Default: int
+"""
+
+    [<Fact>]
+    let ``Anonymous struct record literal``() =
+        Oak() {
+            AnonymousModule() {
+                Value(
+                    "p",
+                    AnonStructRecordExpr(
+                        [ RecordFieldExpr("Name", ConstantExpr(String "Edgar"))
+                          RecordFieldExpr("Age", ConstantExpr(Int 42)) ]
+                    )
+                )
+            }
+        }
+        |> produces
+            """
+let p = struct {| Name = "Edgar"; Age = 42 |}
+"""
+
+    [<Fact>]
+    let ``Units of measure type definitions``() =
+        Oak() {
+            AnonymousModule() {
+                Measure("m")
+                Measure("s")
+                Measure("kg")
+            }
+        }
+        |> produces
+            """
+[<Measure>]
+type m
+
+[<Measure>]
+type s
+
+[<Measure>]
+type kg
+"""
+
+    [<Fact>]
+    let ``Lambda with tuple-destructured parameter``() =
+        Oak() {
+            AnonymousModule() {
+                Value(
+                    "addPair",
+                    LambdaExpr(
+                        [ ParenPat(TuplePat([ NamedPat("a"); NamedPat("b") ])) ],
+                        InfixAppExpr(ConstantExpr(Constant "a"), "+", ConstantExpr(Constant "b"))
+                    )
+                )
+            }
+        }
+        |> produces
+            """
+let addPair = fun (a, b) -> a + b
+"""
+
+    [<Fact>]
+    let ``Try / with single-clause expression``() =
+        Oak() {
+            AnonymousModule() {
+                Value(
+                    "result",
+                    TryWithSingleClauseExpr(
+                        AppExpr(ConstantExpr(Constant "System.Int32.Parse"), [ ConstantExpr(String "42") ]),
+                        MatchClauseExpr(NamedPat("ex"), ConstantExpr(Int 0))
+                    )
+                )
+            }
+        }
+        |> produces
+            """
+let result =
+    try
+        System.Int32.Parse "42"
+    with ex ->
+        0
+"""
+
+    [<Fact>]
+    let ``For-each loop over a list``() =
+        Oak() {
+            AnonymousModule() {
+                Value(
+                    "go",
+                    ForEachDoExpr(
+                        NamedPat("x"),
+                        ArrayExpr([ ConstantExpr(Int 1); ConstantExpr(Int 2); ConstantExpr(Int 3) ]),
+                        AppExpr(
+                            ConstantExpr(Constant "printfn"),
+                            [ ConstantExpr(String "%d"); ConstantExpr(Constant "x") ]
+                        )
+                    )
+                )
+            }
+        }
+        |> produces
+            """
+let go =
+    for x in [| 1; 2; 3 |] do
+        printfn "%d" x
+"""

--- a/src/Fabulous.AST.Tests/Specialized/Properties.fs
+++ b/src/Fabulous.AST.Tests/Specialized/Properties.fs
@@ -1,0 +1,176 @@
+namespace Fabulous.AST.Tests.Specialized
+
+open Fabulous.AST
+open Fabulous.AST.Tests
+open Xunit
+open FsCheck
+
+open type Ast
+
+/// Property-based tests using FsCheck. These verify invariants that hold across
+/// many random inputs, complementing the hand-written example-based tests.
+///
+/// We use the FsCheck core API directly (not FsCheck.Xunit's [<Property>]) because
+/// the pinned FsCheck.Xunit 2.x targets xunit v2, while this project uses xunit.v3.
+module Properties =
+
+    /// Render a widget tree to its formatted F# string.
+    let private renderModule(decls: WidgetBuilder<Fantomas.Core.SyntaxOak.ModuleDecl> list) =
+        let oak =
+            Oak() {
+                AnonymousModule() {
+                    for d in decls do
+                        d
+                }
+            }
+
+        Gen.mkOak oak |> Gen.run
+
+    /// Identifiers that won't trip name validation / backtick escaping.
+    let private safeIdentifier =
+        Gen.elements [ "x"; "y"; "z"; "value"; "result"; "input"; "output"; "foo"; "bar"; "baz" ]
+
+    /// Generate a non-empty list (FsCheck's default can produce empty lists).
+    let private nonEmptyListOf gen =
+        gen |> Gen.listOf |> Gen.filter(fun xs -> not(List.isEmpty xs))
+
+    [<Fact>]
+    let ``Value bindings produce one let per binding, in declared order``() =
+        let prop(names: NonEmptyArray<NonEmptyString>) =
+            let identifiers =
+                names.Get
+                |> Array.map(fun s -> "v_" + System.Text.RegularExpressions.Regex.Replace(s.Get, "[^a-zA-Z0-9_]", "_"))
+                |> Array.distinct
+                |> Array.truncate 5
+                |> Array.toList
+
+            if List.isEmpty identifiers then
+                true
+            else
+                let oak =
+                    Oak() {
+                        AnonymousModule() {
+                            for n in identifiers do
+                                Value(n, ConstantExpr(Int 0))
+                        }
+                    }
+
+                let rendered = Gen.mkOak oak |> Gen.run
+
+                // Each identifier should appear in the output, in the same order.
+                let lines = rendered.Split('\n')
+
+                let letLines =
+                    lines
+                    |> Array.filter(fun l -> l.StartsWith("let "))
+                    |> Array.map(fun l ->
+                        // "let foo = 0" -> "foo"
+                        let s = l.Substring(4).Trim()
+                        s.Split([| ' '; '=' |]).[0])
+                    |> Array.toList
+
+                letLines = identifiers
+
+        Check.QuickThrowOnFailure prop
+
+    [<Fact>]
+    let ``Union with N cases names each case exactly once``() =
+        let prop(caseCount: PositiveInt) =
+            let n = min caseCount.Get 8
+
+            let caseNames = [ for i in 1..n -> sprintf "Case%d" i ]
+
+            let oak =
+                Oak() {
+                    AnonymousModule() {
+                        Union("U") {
+                            for c in caseNames do
+                                UnionCase(c)
+                        }
+                    }
+                }
+
+            let rendered = Gen.mkOak oak |> Gen.run
+
+            // Each case name should appear exactly once in the output.
+            // (Single-case unions render inline like `type U = | Case1`,
+            // multi-case unions break across lines — but each case appears once either way.)
+            caseNames
+            |> List.forall(fun name ->
+                let occurrences =
+                    System.Text.RegularExpressions.Regex.Matches(rendered, "\\b" + name + "\\b").Count
+
+                occurrences = 1)
+
+        Check.QuickThrowOnFailure prop
+
+    [<Fact>]
+    let ``Record with N fields produces N field lines``() =
+        let prop(fieldCount: PositiveInt) =
+            let n = min fieldCount.Get 8
+
+            let fieldNames = [ for i in 1..n -> sprintf "Field%d" i ]
+
+            let oak =
+                Oak() {
+                    AnonymousModule() {
+                        Record("R") {
+                            for fn in fieldNames do
+                                Field(fn, Int())
+                        }
+                    }
+                }
+
+            let rendered = Gen.mkOak oak |> Gen.run
+
+            // Each field should appear exactly once.
+            fieldNames
+            |> List.forall(fun fn ->
+                let count =
+                    rendered.Split('\n') |> Array.filter(fun l -> l.Contains(fn)) |> Array.length
+
+                count = 1)
+
+        Check.QuickThrowOnFailure prop
+
+    [<Fact>]
+    let ``Tuple expression with N items always renders with N-1 commas``() =
+        let prop(itemCount: PositiveInt) =
+            let n = max 2 (min itemCount.Get 8)
+
+            let items = [ for i in 1..n -> ConstantExpr(Int i) ]
+
+            let oak = Oak() { AnonymousModule() { Value("t", TupleExpr(items)) } }
+
+            let rendered = Gen.mkOak oak |> Gen.run
+
+            // The line with the tuple should have exactly n-1 commas.
+            let tupleLine = rendered.Split('\n') |> Array.find(fun l -> l.Contains("let t"))
+
+            let commaCount = tupleLine |> Seq.filter(fun c -> c = ',') |> Seq.length
+
+            commaCount = n - 1
+
+        Check.QuickThrowOnFailure prop
+
+    [<Fact>]
+    let ``XmlDocs lines on a binding render as preceding triple-slash comments``() =
+        let prop(lineCount: PositiveInt) =
+            let n = min lineCount.Get 5
+
+            let docLines = [ for i in 1..n -> sprintf "Doc line %d" i ]
+
+            let oak =
+                Oak() { AnonymousModule() { (Value("x", ConstantExpr(Int 0))).xmlDocs(docLines) } }
+
+            let rendered = Gen.mkOak oak |> Gen.run
+
+            // Output should contain exactly N "///" prefixed lines.
+            let docLineCount =
+                rendered.Split('\n')
+                |> Array.filter(fun l -> l.TrimStart().StartsWith("///"))
+                |> Array.length
+
+            docLineCount = n
+
+        Check.QuickThrowOnFailure prop

--- a/src/Fabulous.AST.Tests/Specialized/RealWorld.fs
+++ b/src/Fabulous.AST.Tests/Specialized/RealWorld.fs
@@ -1,0 +1,175 @@
+namespace Fabulous.AST.Tests.Specialized
+
+open Fabulous.AST
+open Fabulous.AST.Tests
+open Xunit
+
+open type Ast
+
+/// Real-world fixture tests — generate complete, realistic F# modules to validate
+/// that the widget API composes well at file-scale, not just per-widget. Each test
+/// produces a substantial chunk of F# code modeled on idiomatic code consumers
+/// would actually write.
+module RealWorld =
+
+    [<Fact>]
+    let ``Small Result/Option-style helper module``() =
+        Oak() {
+            AnonymousModule() {
+                Module("Result") {
+                    Function(
+                        "map",
+                        [ NamedPat("f"); NamedPat("r") ],
+                        MatchExpr(
+                            ConstantExpr(Constant "r"),
+                            [ MatchClauseExpr(
+                                  LongIdentPat("Ok", NamedPat("v")),
+                                  AppExpr(
+                                      ConstantExpr(Constant "Ok"),
+                                      [ ParenExpr(AppExpr(ConstantExpr(Constant "f"), [ ConstantExpr(Constant "v") ])) ]
+                                  )
+                              )
+                              MatchClauseExpr(
+                                  LongIdentPat("Error", NamedPat("e")),
+                                  AppExpr(ConstantExpr(Constant "Error"), [ ConstantExpr(Constant "e") ])
+                              ) ]
+                        )
+                    )
+
+                    Function(
+                        "bind",
+                        [ NamedPat("f"); NamedPat("r") ],
+                        MatchExpr(
+                            ConstantExpr(Constant "r"),
+                            [ MatchClauseExpr(
+                                  LongIdentPat("Ok", NamedPat("v")),
+                                  AppExpr(ConstantExpr(Constant "f"), [ ConstantExpr(Constant "v") ])
+                              )
+                              MatchClauseExpr(
+                                  LongIdentPat("Error", NamedPat("e")),
+                                  AppExpr(ConstantExpr(Constant "Error"), [ ConstantExpr(Constant "e") ])
+                              ) ]
+                        )
+                    )
+
+                    Function(
+                        "defaultValue",
+                        [ NamedPat("d"); NamedPat("r") ],
+                        MatchExpr(
+                            ConstantExpr(Constant "r"),
+                            [ MatchClauseExpr(LongIdentPat("Ok", NamedPat("v")), ConstantExpr(Constant "v"))
+                              MatchClauseExpr(LongIdentPat("Error", WildPat()), ConstantExpr(Constant "d")) ]
+                        )
+                    )
+                }
+            }
+        }
+        |> produces
+            """
+module Result =
+    let map f r =
+        match r with
+        | Ok v -> Ok (f v)
+        | Error e -> Error e
+
+    let bind f r =
+        match r with
+        | Ok v -> f v
+        | Error e -> Error e
+
+    let defaultValue d r =
+        match r with
+        | Ok v -> v
+        | Error _ -> d
+"""
+
+    [<Fact>]
+    let ``Domain types: discriminated union + record + helper functions``() =
+        Oak() {
+            Namespace("Shopping") {
+                (Union("PaymentMethod") {
+                    UnionCase("Cash")
+                    UnionCase("Card", Field("last4", String()))
+                    UnionCase("Voucher", [ Field("code", String()); Field("amount", Float()) ])
+                })
+                    .xmlDocs([ "How a customer paid." ])
+
+                (Record("Order") {
+                    Field("Id", LongIdent "System.Guid")
+                    Field("Total", Float())
+                    Field("Payment", LongIdent "PaymentMethod")
+                })
+                    .xmlDocs([ "A completed customer order." ])
+
+                Module("Order") {
+                    Function(
+                        "isPaidInFull",
+                        [ NamedPat("order") ],
+                        MatchExpr(
+                            ConstantExpr(Constant "order.Payment"),
+                            [ MatchClauseExpr(LongIdentPat("Cash"), ConstantExpr(Bool true))
+                              MatchClauseExpr(LongIdentPat("Card", WildPat()), ConstantExpr(Bool true))
+                              MatchClauseExpr(
+                                  LongIdentPat("Voucher", ParenPat(TuplePat([ WildPat(); NamedPat("amount") ]))),
+                                  InfixAppExpr(
+                                      ConstantExpr(Constant "amount"),
+                                      ">=",
+                                      ConstantExpr(Constant "order.Total")
+                                  )
+                              ) ]
+                        )
+                    )
+                }
+            }
+        }
+        |> produces
+            """
+namespace Shopping
+
+/// How a customer paid.
+type PaymentMethod =
+    | Cash
+    | Card of last4: string
+    | Voucher of code: string * amount: float
+
+/// A completed customer order.
+type Order =
+    { Id: System.Guid
+      Total: float
+      Payment: PaymentMethod }
+
+module Order =
+    let isPaidInFull order =
+        match order.Payment with
+        | Cash -> true
+        | Card _ -> true
+        | Voucher(_, amount) -> amount >= order.Total
+"""
+
+    [<Fact>]
+    let ``Class implementing IDisposable with constructor parameter``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("FileHandle", ParenPat(ParameterPat("path", String()))) {
+                    Member("this.Path", ConstantExpr(Constant "path"))
+
+                    Member(
+                        "this.Exists",
+                        AppExpr(ConstantExpr(Constant "System.IO.File.Exists"), [ ConstantExpr(Constant "this.Path") ])
+                    )
+
+                    InterfaceWith(LongIdent "System.IDisposable") {
+                        Member("this.Dispose", UnitPat(), ConstantExpr(Constant "()"))
+                    }
+                }
+            }
+        }
+        |> produces
+            """
+type FileHandle(path: string) =
+    member this.Path = path
+    member this.Exists = System.IO.File.Exists this.Path
+
+    interface System.IDisposable with
+        member this.Dispose() = ()
+"""


### PR DESCRIPTION
## Summary

Adds **21 new tests** across 4 specialized categories under `src/Fabulous.AST.Tests/Specialized/`. These complement the existing ~726 per-widget happy-path tests by exercising scenarios that exist at the seams between widgets, at file scale, and across random inputs.

| Category | Tests | What it covers |
|---|---|---|
| **Composition** (`Composition.fs`) | 5 | Multi-widget shapes: interface + class + inheritance + interface impl with attributes/xmldocs; DU + helper function; record with computed member + interface; namespace with nested module + abbreviations; mutually recursive types |
| **F# 8/9/10 features** (`FSharpFeatures.fs`) | 8 | `static abstract` members + properties (IWSAMs); anonymous struct records; units of measure; tuple-destructured lambda parameter; `try/with` single-clause; `for…do` loop; **type extension via `Augmentation`** |
| **Real-world fixtures** (`RealWorld.fs`) | 3 | File-scale generation: a `Result` helper module; domain types (DU + record + helper function); class implementing `IDisposable` |
| **Property tests** (`Properties.fs`) | 5 | FsCheck invariants: value bindings preserve order; DU cases appear exactly once; record fields appear exactly once; tuple comma count = N−1; xmldoc lines render as `///` |

## Verification

- `dotnet fsi build.fsx` green: lint, build (net8.0/net10.0/netstandard2.1), tests, docs, pack
- Test suite: **801/801 pass** on both `net8.0` and `net10.0` (was 780/780; +21 new tests, no regressions)

## Property test infrastructure note

`FsCheck.Xunit 2.16.6` (the pinned version) targets `xunit v2`, but this project uses `xunit.v3`. So the existing `FsCheck.Xunit` reference can't actually be used — its `[<Property>]` attribute doesn't bind. As a minimal workaround this PR adds an explicit `FsCheck` (core) reference at the same 2.16.6 version that `FsCheck.Xunit` already pulled in transitively, and the property tests call `Check.QuickThrowOnFailure` from inside a `[<Fact>]`. This avoids any infra churn; a future PR could bump `FsCheck.Xunit` to 3.x (xunit-v3-compatible) and convert to `[<Property>]` if desired.

## API gaps surfaced while writing these tests (and one correction)

Worth flagging as follow-ups — not blocking this PR:

1. **No `.toOverride()` modifier** on `WidgetBuilder<MemberDefn>`. F#'s `override` keyword cannot currently be generated, so overriding members in subclasses isn't expressible. (`SingleTextNode.override` exists but no widget exposes it.)
2. ~~**No `.toExtension()` modifier**~~ — **corrected:** the `Augmentation(name) { ... }` collection builder already exists and produces `type X with member ...`. A regression test was added to `FSharpFeatures.fs` to cover it. The collection-builder shape is preferable to a `.toModifier()` for this scenario.
3. **`.toRecursive()` is widget-specific.** Defined on `WidgetBuilder<TypeDefn>` so it appears generic, but only the `Union`, `Delegate`, `Record`, and `TypeDefnRegular` widget keys actually *read* `TypeDefn.IsRecursive`. It's silently a no-op on `Abbrev`, `Enum`, `Augment`, `TypeDefnExplicit`, and `Measure` — meaning a mutually-recursive type group cannot include any of those kinds. The workaround in the test suite was to use two Unions instead of an Abbrev+Union pair.

The third one is the most worth following up on — same diagnosis pattern as the dead `IsStatic` scalars we removed in PR #178.
