### PR TITLE
fix: read TypeDefn.IsRecursive in Abbrev, Enum, TypeDefnExplicit, Measure

### DIFF
--- a/src/Fabulous.AST.Tests/TypeDefinitions/Abbrev.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Abbrev.fs
@@ -163,6 +163,22 @@ type MyFloat = float
 """
 
     [<Fact>]
+    let ``Recursive abbreviation renders with `and` keyword``() =
+        Oak() {
+            AnonymousModule() {
+                Union("Tree") { UnionCase("Leaf") }
+
+                Abbrev("Forest", AppPrefix(LongIdent "list", [ LongIdent "Tree" ]))
+                |> _.toRecursive()
+            }
+        }
+        |> produces
+            """
+type Tree = | Leaf
+and Forest = list<Tree>
+"""
+
+    [<Fact>]
     let ``yield! multiple type abbreviations``() =
         Oak() {
             AnonymousModule() {

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Class.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Class.fs
@@ -345,6 +345,25 @@ type Person<'a, 'b>() =
 """
 
     [<Fact>]
+    let ``Recursive explicit type definition renders with `and` keyword``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Foo", UnitPat()) { Member("this.X", ConstantExpr(Int 0)) }
+
+                TypeDefn("Bar", UnitPat()) { Member("this.Y", ConstantExpr(Int 0)) }
+                |> _.toRecursive()
+            }
+        }
+        |> produces
+            """
+type Foo() =
+    member this.X = 0
+
+and Bar() =
+    member this.Y = 0
+"""
+
+    [<Fact>]
     let ``Produces a struct generic class with a constructor``() =
         Oak() {
             AnonymousModule() {

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Enum.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Enum.fs
@@ -280,6 +280,24 @@ type Sizes =
 """
 
     [<Fact>]
+    let ``Recursive enum renders with `and` keyword``() =
+        Oak() {
+            AnonymousModule() {
+                Enum("Sizes") { EnumCase("Small", Int(0)) }
+
+                Enum("Colors") { EnumCase("Red", Int(0)) } |> _.toRecursive()
+            }
+        }
+        |> produces
+            """
+type Sizes =
+    | Small = 0
+
+and Colors =
+    | Red = 0
+"""
+
+    [<Fact>]
     let ``yield! multiple enum cases``() =
         Oak() {
             AnonymousModule() {

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
@@ -125,3 +125,19 @@ type Ml = cm^3
 [<Measure; Obsolete>]
 type cm
 """
+
+    [<Fact>]
+    let ``Recursive measure renders with `and` keyword``() =
+        Oak() {
+            AnonymousModule() {
+                Measure("m")
+                Measure("s") |> _.toRecursive()
+            }
+        }
+        |> produces
+            """
+[<Measure>]
+type m
+
+and [<Measure>] s
+"""

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Abbrev.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Abbrev.fs
@@ -31,12 +31,17 @@ module TypeDefnAbbrevNode =
                 |> ValueOption.map MultipleAttributeListNode.Create
                 |> ValueOption.toOption
 
+            let leadingKeyword =
+                Widgets.tryGetScalarValue widget TypeDefn.IsRecursive
+                |> ValueOption.map(fun _ -> SingleTextNode.``and``)
+                |> ValueOption.defaultValue SingleTextNode.``type``
+
             TypeDefn.Abbrev(
                 TypeDefnAbbrevNode(
                     TypeNameNode(
                         xmlDocs,
                         attributes,
-                        SingleTextNode.``type``,
+                        leadingKeyword,
                         None,
                         IdentListNode([ IdentifierOrDot.Ident(SingleTextNode.Create(name)) ], Range.Zero),
                         typeParams,

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Enum.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Enum.fs
@@ -29,12 +29,17 @@ module Enum =
                 |> ValueOption.map MultipleAttributeListNode.Create
                 |> ValueOption.toOption
 
+            let leadingKeyword =
+                Widgets.tryGetScalarValue widget TypeDefn.IsRecursive
+                |> ValueOption.map(fun _ -> SingleTextNode.``and``)
+                |> ValueOption.defaultValue SingleTextNode.``type``
+
             TypeDefn.Enum(
                 TypeDefnEnumNode(
                     TypeNameNode(
                         xmlDocs,
                         attributes,
-                        SingleTextNode.``type``,
+                        leadingKeyword,
                         Some(SingleTextNode.Create(name)),
                         IdentListNode([ IdentifierOrDot.Ident(SingleTextNode.equals) ], Range.Zero),
                         None,

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Measure.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Measure.fs
@@ -33,11 +33,16 @@ module TypeNameNode =
                 | Some(multipleAttributes) -> measureAttribute @ List.ofSeq multipleAttributes
                 | None -> measureAttribute
 
+            let leadingKeyword =
+                Widgets.tryGetScalarValue widget TypeDefn.IsRecursive
+                |> ValueOption.map(fun _ -> SingleTextNode.``and``)
+                |> ValueOption.defaultValue SingleTextNode.``type``
+
             TypeDefn.None(
                 TypeNameNode(
                     xmlDocs,
                     Some(MultipleAttributeListNode.Create(attributes)),
-                    SingleTextNode.``type``,
+                    leadingKeyword,
                     Some(SingleTextNode.Create(name)),
                     IdentListNode([], Range.Zero),
                     None,

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnExplicit.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/TypeDefnExplicit.fs
@@ -56,12 +56,17 @@ module TypeDefnExplicit =
                 Widgets.tryGetNodesFromWidgetCollection widget Members
                 |> ValueOption.defaultValue []
 
+            let leadingKeyword =
+                Widgets.tryGetScalarValue widget TypeDefn.IsRecursive
+                |> ValueOption.map(fun _ -> SingleTextNode.``and``)
+                |> ValueOption.defaultValue SingleTextNode.``type``
+
             TypeDefn.Explicit(
                 TypeDefnExplicitNode(
                     TypeNameNode(
                         xmlDocs,
                         attributes,
-                        SingleTextNode.``type``,
+                        leadingKeyword,
                         accessControl,
                         IdentListNode([ IdentifierOrDot.Ident(SingleTextNode.Create(name)) ], Range.Zero),
                         typeParams,


### PR DESCRIPTION
## Summary

Fixes the `.toRecursive()` modifier being silently a no-op on `Abbrev`, `Enum`, `TypeDefnExplicit`, and `Measure` widget types.

`.toRecursive()` on `WidgetBuilder<TypeDefn>` writes the `TypeDefn.IsRecursive` scalar. The intent is to switch the rendered leading keyword from `type` to `and`, so a type definition can appear inside a mutually-recursive type group (`type A = … and B = …`). But only `Union`, `Delegate`, `Record`, and `TypeDefnRegular` actually *read* the scalar — the other four widget keys hardcoded `SingleTextNode.``type`` ` and ignored the scalar entirely.

This surfaced while writing the specialized composition tests in PR #181 (the "mutually recursive union types" test had to use two `Union`s instead of the more natural `Union + Abbrev` because the abbreviation's `.toRecursive()` did nothing).

Same diagnosis pattern as the dead `IsStatic` scalars removed in PR #178.

## Fix

In each of the four broken widget keys, replace the hardcoded `SingleTextNode.``type`` ` with a computed `leadingKeyword` that reads `TypeDefn.IsRecursive` — the same one-liner pattern `Delegate.fs` already uses:

```fsharp
let leadingKeyword =
    Widgets.tryGetScalarValue widget TypeDefn.IsRecursive
    |> ValueOption.map(fun _ -> SingleTextNode.``and``)
    |> ValueOption.defaultValue SingleTextNode.``type``
```

`Augmentation` is intentionally not patched — F# does not allow `and X with member …` for type extensions; extensions don't participate in mutually-recursive type definition groups.

## Tests

Adds 4 regression tests, one per fixed widget:

| File | New test |
|---|---|
| `TypeDefinitions/Abbrev.fs` | `Recursive abbreviation renders with `and` keyword` |
| `TypeDefinitions/Enum.fs` | `Recursive enum renders with `and` keyword` |
| `TypeDefinitions/Class.fs` | `Recursive explicit type definition renders with `and` keyword` |
| `TypeDefinitions/Measure.fs` | `Recursive measure renders with `and` keyword` |

## Verification

- `dotnet fsi build.fsx` green: lint, build (net8.0/net10.0/netstandard2.1), tests, docs, pack
- Test suite: **784/784 pass** on both `net8.0` and `net10.0` (was 780/780; +4 new regression tests, no regressions)
