### PR TITLE
feat: add toOverride() modifier for member definitions

### DIFF
--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -43,6 +43,7 @@
         <Compile Include="MemberDefinitions\AbstractSlot.fs" />
         <Compile Include="MemberDefinitions\AutoProperty.fs" />
         <Compile Include="MemberDefinitions\PropertyGetSet.fs" />
+        <Compile Include="MemberDefinitions\Override.fs" />
         <Compile Include="MemberDefinitions\InheritConstructor.fs" />
         <Compile Include="MemberDefinitions\Inherit.fs" />
         <Compile Include="MemberDefinitions\ExplicitConstructor.fs" />

--- a/src/Fabulous.AST.Tests/MemberDefinitions/Override.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/Override.fs
@@ -1,0 +1,86 @@
+namespace Fabulous.AST.Tests.MemberDefinitions
+
+open Fabulous.AST
+open Fabulous.AST.Tests
+open Xunit
+
+open type Ast
+
+/// Tests for the `.toOverride()` modifier across the four widget types that
+/// render the `member` keyword: Method, Property (computed), AutoProperty
+/// (`member val`), and PropertyGetSet (`member ... with get/set`).
+module Override =
+
+    [<Fact>]
+    let ``Method member rendered as override``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Derived", UnitPat()) {
+                    Inherit("Base()")
+
+                    Member("this.Show", UnitPat(), ConstantExpr(String "derived")).toOverride()
+                }
+            }
+        }
+        |> produces
+            """
+type Derived() =
+    inherit Base()
+    override this.Show() = "derived"
+"""
+
+    [<Fact>]
+    let ``Computed property member rendered as override``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Derived", UnitPat()) {
+                    Inherit("Base()")
+
+                    Member("this.Name", ConstantExpr(String "x")).toOverride()
+                }
+            }
+        }
+        |> produces
+            """
+type Derived() =
+    inherit Base()
+    override this.Name = "x"
+"""
+
+    [<Fact>]
+    let ``Auto property (member val) rendered as override``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Derived", UnitPat()) {
+                    Inherit("Base()")
+
+                    MemberVal("Name", ConstantExpr(String "x"), String(), hasGetter = true).toOverride()
+                }
+            }
+        }
+        |> produces
+            """
+type Derived() =
+    inherit Base()
+    override val Name: string = "x" with get
+"""
+
+    [<Fact>]
+    let ``PropertyGetSet member rendered as override``() =
+        Oak() {
+            AnonymousModule() {
+                TypeDefn("Derived", UnitPat()) {
+                    Inherit("Base()")
+
+                    Member("this.Position", Getter(ConstantExpr(Int 0))).toOverride()
+                }
+            }
+        }
+        |> produces
+            """
+type Derived() =
+    inherit Base()
+
+    override this.Position
+        with get () = 0
+"""

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/AutoProperty.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/AutoProperty.fs
@@ -44,6 +44,10 @@ module AutoPropertyMember =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
                 |> ValueOption.defaultValue false
 
+            let isOverride =
+                Widgets.tryGetScalarValue widget BindingNode.IsOverride
+                |> ValueOption.defaultValue false
+
             let returnType =
                 Widgets.tryGetNodeFromWidget widget ReturnType |> ValueOption.toOption
 
@@ -56,11 +60,11 @@ module AutoPropertyMember =
                 MultipleTextsNode(
                     [ if isStatic then
                           SingleTextNode.``static``
-                          SingleTextNode.``member``
-                          SingleTextNode.``val``
+                      if isOverride then
+                          SingleTextNode.``override``
                       else
                           SingleTextNode.``member``
-                          SingleTextNode.``val`` ],
+                      SingleTextNode.``val`` ],
                     Range.Zero
                 )
 

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Method.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Method.fs
@@ -21,6 +21,10 @@ module BindingMethodNode =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
                 |> ValueOption.defaultValue false
 
+            let isOverride =
+                Widgets.tryGetScalarValue widget BindingNode.IsOverride
+                |> ValueOption.defaultValue false
+
             let returnType =
                 Widgets.tryGetNodeFromWidget widget BindingNode.Return
                 |> ValueOption.map(fun value -> BindingReturnInfoNode(SingleTextNode.colon, value, Range.Zero))
@@ -58,7 +62,8 @@ module BindingMethodNode =
             let multipleTextsNode =
                 [ if isStatic then
                       SingleTextNode.``static``
-                      SingleTextNode.``member``
+                  if isOverride then
+                      SingleTextNode.``override``
                   else
                       SingleTextNode.``member`` ]
 

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/Property.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/Property.fs
@@ -19,6 +19,10 @@ module BindingProperty =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
                 |> ValueOption.defaultValue false
 
+            let isOverride =
+                Widgets.tryGetScalarValue widget BindingNode.IsOverride
+                |> ValueOption.defaultValue false
+
             let returnType =
                 Widgets.tryGetNodeFromWidget widget BindingNode.Return
                 |> ValueOption.map(fun value -> BindingReturnInfoNode(SingleTextNode.colon, value, Range.Zero))
@@ -56,7 +60,8 @@ module BindingProperty =
             let multipleTextsNode =
                 [ if isStatic then
                       SingleTextNode.``static``
-                      SingleTextNode.``member``
+                  if isOverride then
+                      SingleTextNode.``override``
                   else
                       SingleTextNode.``member`` ]
 

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/PropertyGetSet.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/PropertyGetSet.fs
@@ -39,15 +39,21 @@ module PropertyGetSetMember =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
                 |> ValueOption.defaultValue false
 
+            let isOverride =
+                Widgets.tryGetScalarValue widget BindingNode.IsOverride
+                |> ValueOption.defaultValue false
+
             let xmlDocs =
                 Widgets.tryGetNodeFromWidget widget MemberDefn.XmlDocs |> ValueOption.toOption
 
             let multipleTextsNode =
                 MultipleTextsNode(
-                    (if isStatic then
-                         [ SingleTextNode.``static``; SingleTextNode.``member`` ]
-                     else
-                         [ SingleTextNode.``member`` ]),
+                    [ if isStatic then
+                          SingleTextNode.``static``
+                      if isOverride then
+                          SingleTextNode.``override``
+                      else
+                          SingleTextNode.``member`` ],
                     Range.Zero
                 )
 

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/_BindingNode.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/_BindingNode.fs
@@ -12,6 +12,7 @@ module BindingNode =
     let XmlDocs = Attributes.defineWidget "XmlDocs"
     let IsInlined = Attributes.defineScalar<bool> "IsInlined"
     let IsStatic = Attributes.defineScalar<bool> "IsStatic"
+    let IsOverride = Attributes.defineScalar<bool> "IsOverride"
 
     let MultipleAttributes =
         Attributes.defineScalar<AttributeNode seq> "MultipleAttributes"
@@ -186,6 +187,28 @@ type BindingNodeModifiers =
         this.AddScalar(BindingNode.IsStatic.WithValue(true))
 
     /// <summary>
+    /// Marks the current member widget as an override (renders `override` instead
+    /// of `member`). Only meaningful for method / property / auto-property members
+    /// inside a class that inherits from a base type with a virtual / abstract
+    /// member of the same name.
+    /// </summary>
+    /// <param name="this">Current widget.</param>
+    /// <code language="fsharp">
+    /// Oak() {
+    ///     AnonymousModule() {
+    ///         TypeDefn("Derived", UnitPat()) {
+    ///             Inherit("Base()")
+    ///             Member("this.Show", UnitPat(), ConstantExpr(String "derived"))
+    ///                 .toOverride()
+    ///         }
+    ///     }
+    /// }
+    /// </code>
+    [<Extension>]
+    static member inline toOverride(this: WidgetBuilder<BindingNode>) =
+        this.AddScalar(BindingNode.IsOverride.WithValue(true))
+
+    /// <summary>
     /// Sets the type parameters for the current widget.
     /// </summary>
     /// <param name="this">Current widget.</param>
@@ -266,6 +289,17 @@ type MemberDefnModifiers =
     [<Extension>]
     static member inline toStatic(this: WidgetBuilder<MemberDefn>) =
         this.AddScalar(BindingNode.IsStatic.WithValue(true))
+
+    /// <summary>
+    /// Marks the current member definition widget as an override (renders
+    /// <c>override</c> instead of <c>member</c>). Only meaningful for method /
+    /// property members in a class that inherits a virtual or abstract member of
+    /// the same name.
+    /// </summary>
+    /// <param name="this">Current widget.</param>
+    [<Extension>]
+    static member inline toOverride(this: WidgetBuilder<MemberDefn>) =
+        this.AddScalar(BindingNode.IsOverride.WithValue(true))
 
     /// <summary>Sets the type parameters for the current member definition widget.</summary>
     /// <param name="this">Current widget.</param>


### PR DESCRIPTION
## Summary

Adds a `.toOverride()` modifier so users can generate F#'s `override` keyword. Previously the widget API could not express overriding members in subclasses — `SingleTextNode.``override`` ` existed but no widget exposed it, and the four widget keys that emit `member` hardcoded the keyword.

Surfaced as an API gap in PR #181 while writing the specialized composition tests.

## Changes

- Add `BindingNode.IsOverride` scalar (sibling to `IsStatic`, `IsInlined`, etc.)
- Add `toOverride()` extension method on `WidgetBuilder<BindingNode>` (mirrors `toStatic`)
- Add `toOverride()` extension method on `WidgetBuilder<MemberDefn>` (mirrors `toStatic`)
- Update the four widget keys that emit `member` to read `BindingNode.IsOverride` and substitute `override` for `member` in their leading-keywords list:
  - `Method.fs` (`member this.X(...) = ...`)
  - `Property.fs` (`member this.X = ...`)
  - `AutoProperty.fs` (`member val X = ... with get/set`)
  - `PropertyGetSet.fs` (`member this.X with get/set ...`)

## Combination semantics

| Modifiers | Renders | F# valid? |
|---|---|---|
| (none) | `member foo …` | ✓ |
| `.toStatic()` | `static member foo …` | ✓ |
| `.toOverride()` | `override foo …` | ✓ |
| `.toStatic().toOverride()` | `static override foo …` | ✗ (F# rejects) |

The static+override combination renders what the user requested even though F# rejects it; the compiler will flag it downstream rather than the widget silently dropping one modifier.

## Tests

Adds `src/Fabulous.AST.Tests/MemberDefinitions/Override.fs` with one test per widget type:

| Test | Widget |
|---|---|
| `Method member rendered as override` | `Method.fs` |
| `Computed property member rendered as override` | `Property.fs` |
| `Auto property (member val) rendered as override` | `AutoProperty.fs` |
| `PropertyGetSet member rendered as override` | `PropertyGetSet.fs` |

## Verification

- `dotnet fsi build.fsx` green: lint, build (net8.0/net10.0/netstandard2.1), tests, docs, pack
- Test suite: **788/788 pass** on both `net8.0` and `net10.0` (was 784/784; +4 new tests, no regressions)
