### PR TITLE
ci: pre-build Fabulous.AST.Build before solution build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,13 @@ jobs:
           dotnet-version: 8.0.x
       - name: Restore
         run: dotnet restore ${SLN_FILE}
+      # Fabulous.AST.Build ships an MSBuild task that samples/Playground consumes
+      # via <UsingTask> in Fabulous.AST.Build.targets. UsingTask conditions are
+      # evaluated at project-load time, so the task DLL must exist on disk before
+      # we build anything that imports those targets. build.fsx already handles
+      # this; the release workflow must too.
+      - name: Pre-build Fabulous.AST.Build
+        run: dotnet build ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-restore
       - name: Build
         run: dotnet build ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-restore
       - name: Test


### PR DESCRIPTION
## Summary

Fixes the `2.0.0-pre07` release workflow run failure: `MSB4036: The "FabulousAstJsonTask" task was not found`.

The release workflow calls `dotnet build` directly on the solution. Without a pre-built `Fabulous.AST.Build.dll`, Playground's `<UsingTask>` (in `Fabulous.AST.Build.targets`) evaluates at project-load time and silently fails to register the task, then the generation target crashes when it tries to invoke it.

Same root cause and same fix as commit `d17fa7b` (which patched `build.fsx`). The release workflow simply didn't get that fix because it doesn't use `build.fsx`.

## Next step after merge

Move the `2.0.0-pre07` tag forward to include this commit, which re-fires the release workflow with the fix applied.

Failed run for reference: https://github.com/edgarfgp/Fabulous.AST/actions/runs/26694853564/job/78677490843
