### PR TITLE
ci: pass changelog release notes via env vars in pack step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,20 @@ jobs:
       - name: Test
         run: dotnet test ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-build
       - name: Pack
+        # Pass the changelog content via env vars rather than ${{ … }} template
+        # interpolation. Direct interpolation embeds the content into the bash
+        # script body before bash parses it, which means backticks, parens, and
+        # other special characters in the changelog get interpreted as shell
+        # syntax (command substitution, etc.). With env-var passing, the
+        # content is just data at runtime.
+        env:
+          RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
+          JSON_RELEASE_NOTES: ${{ steps.json_changelog.outputs.changes }}
+          BUILD_RELEASE_NOTES: ${{ steps.build_changelog.outputs.changes }}
         run: |
-          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="${{ steps.changelog_reader.outputs.changes }}" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="${{ steps.json_changelog.outputs.changes }}" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="${{ steps.build_changelog.outputs.changes }}" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$JSON_RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$BUILD_RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the second `2.0.0-pre07` release failure (run [26695038633](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26695038633/job/78678004419)). Different root cause from #185.

The release workflow's `Pack` step embedded the changelog section content directly into the bash script via `${{ steps.changelog_reader.outputs.changes }}`. GitHub Actions templates this *before* bash parses the script, so backticks in the changelog (e.g. `` `FSharp.Core` ``, `` `Seq.length` ``) trigger command substitution at script-parse time, parens fragment the `dotnet pack` invocation, and the whole command turns into garbage.

The previous release's changelog entry was a single line with minimal markup, so this latent bug never surfaced. The `2.0.0-pre07` entries are multi-line with backticks throughout.

## Fix

Pass each release-notes string through an env var instead. With env-var passing, bash sees `"$RELEASE_NOTES"` (a variable reference) and substitutes the value at runtime as data — special characters are preserved without interpretation as shell syntax.

## Next step after merge

Move the `2.0.0-pre07` tag forward again to include this commit, which re-fires the release workflow.
