### PR TITLE
ci: escape semicolons in MSBuild release-notes property values

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,22 @@ jobs:
         # other special characters in the changelog get interpreted as shell
         # syntax (command substitution, etc.). With env-var passing, the
         # content is just data at runtime.
+        #
+        # MSBuild's `-p:Key=Value` syntax treats `;` as a delimiter between
+        # properties. Escape `;` in property values as `%3B` so multi-line
+        # changelog content containing semicolons (e.g. `net8.0;net10.0`,
+        # or English sentences with `;` clauses) doesn't get split mid-value.
         env:
           RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
           JSON_RELEASE_NOTES: ${{ steps.json_changelog.outputs.changes }}
           BUILD_RELEASE_NOTES: ${{ steps.build_changelog.outputs.changes }}
         run: |
-          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$JSON_RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$BUILD_RELEASE_NOTES" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          RELEASE_NOTES_ESC="${RELEASE_NOTES//;/%3B}"
+          JSON_RELEASE_NOTES_ESC="${JSON_RELEASE_NOTES//;/%3B}"
+          BUILD_RELEASE_NOTES_ESC="${BUILD_RELEASE_NOTES//;/%3B}"
+          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$JSON_RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$BUILD_RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Fixes the third `2.0.0-pre07` release failure ([run 26695172164](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26695172164/job/78678676921)).

After #186 fixed the shell-quoting issue, MSBuild now actually parses the property value — and runs straight into its own quoting rule. `dotnet pack -p:Key=Value` treats `;` in `Value` as a delimiter starting the next `Key=Value` pair, splitting the release notes mid-content. Hit by:

- `net8.0;net10.0` in the target-frameworks entry
- `for the main library; tests now multi-target …` (English `;` clause)

MSBuild then tries to parse "tests now multi-target `net8.0" as a property name and bails with `MSB1006: Property is not valid`.

## Fix

Escape `;` as `%3B` in each release-notes string before passing it. `%3B` is MSBuild's URL-style escape for literal semicolons in property values. Bash parameter expansion `${VAR//;/%3B}` does the substitution in place — no extra tooling needed.

## Next step after merge

Move the `2.0.0-pre07` tag forward again to include this commit.
