### PR TITLE
ci: source release notes via env-var-backed MSBuild property

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,28 +69,22 @@ jobs:
       - name: Test
         run: dotnet test ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --no-build
       - name: Pack
-        # Pass the changelog content via env vars rather than ${{ … }} template
-        # interpolation. Direct interpolation embeds the content into the bash
-        # script body before bash parses it, which means backticks, parens, and
-        # other special characters in the changelog get interpreted as shell
-        # syntax (command substitution, etc.). With env-var passing, the
-        # content is just data at runtime.
-        #
-        # MSBuild's `-p:Key=Value` syntax treats `;` as a delimiter between
-        # properties. Escape `;` in property values as `%3B` so multi-line
-        # changelog content containing semicolons (e.g. `net8.0;net10.0`,
-        # or English sentences with `;` clauses) doesn't get split mid-value.
+        # Release notes are sourced via env vars that Directory.Build.props
+        # picks up as MSBuild properties (auto-imported). This avoids the
+        # fragility of `-p:PackageReleaseNotes="..."` on the command line,
+        # which has to navigate shell quoting (backticks → command
+        # substitution), MSBuild `;` property delimiters, `/` switch prefixes,
+        # and embedded newlines. By the time MSBuild evaluates
+        # $(RELEASE_NOTES) inside Directory.Build.props, the value is an
+        # opaque string from the environment with no parser between us and it.
         env:
           RELEASE_NOTES: ${{ steps.changelog_reader.outputs.changes }}
           JSON_RELEASE_NOTES: ${{ steps.json_changelog.outputs.changes }}
           BUILD_RELEASE_NOTES: ${{ steps.build_changelog.outputs.changes }}
         run: |
-          RELEASE_NOTES_ESC="${RELEASE_NOTES//;/%3B}"
-          JSON_RELEASE_NOTES_ESC="${JSON_RELEASE_NOTES//;/%3B}"
-          BUILD_RELEASE_NOTES_ESC="${BUILD_RELEASE_NOTES//;/%3B}"
-          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$JSON_RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
-          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -p:PackageReleaseNotes="$BUILD_RELEASE_NOTES_ESC" -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${SLN_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${JSON_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
+          dotnet pack ${BUILD_FILE} -p:Version=${RELEASE_VERSION} -c ${CONFIG} --property PackageOutputPath=${PWD}/nupkgs
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,6 +20,20 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <!--
+    Per-package release notes, sourced from env vars set by the release workflow.
+    MSBuild auto-imports env vars as properties, so the values come in as
+    opaque strings without going through any command-line parser. Avoids the
+    fragility of `-p:PackageReleaseNotes=...` on the dotnet pack command line,
+    which has to deal with shell quoting, MSBuild `;` property delimiters,
+    `/` switch prefixes, and embedded newlines.
+  -->
+  <PropertyGroup>
+    <PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST' AND '$(RELEASE_NOTES)' != ''">$(RELEASE_NOTES)</PackageReleaseNotes>
+    <PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST.Json' AND '$(JSON_RELEASE_NOTES)' != ''">$(JSON_RELEASE_NOTES)</PackageReleaseNotes>
+    <PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST.Build' AND '$(BUILD_RELEASE_NOTES)' != ''">$(BUILD_RELEASE_NOTES)</PackageReleaseNotes>
+  </PropertyGroup>
+
   <PropertyGroup>
     <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen --strict-indentation+ --realsig+</OtherFlags>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>


### PR DESCRIPTION
## Summary

Fixes the persistent `2.0.0-pre07` release failure. Three serial attempts hit three different escaping bugs trying to pass multi-line markdown changelog content through `dotnet pack -p:PackageReleaseNotes="..."`:

| Run | Error | Cause |
|---|---|---|
| [#26694853564](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26694853564) | `MSB4036: FabulousAstJsonTask not found` | (different issue, fixed in #185) |
| [#26695038633](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26695038633) | `command not found` for ~30 words | Backticks in changelog → bash command substitution at script parse |
| [#26695172164](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26695172164) | `MSB1006: Property is not valid. Switch: tests now multi-target` | `;` in `net8.0;net10.0` → MSBuild property delimiter splits the value |
| [#26695437419](https://github.com/edgarfgp/Fabulous.AST/actions/runs/26695437419) | `MSB1006: Property is not valid. Switch: matching the accessibility…` | `/` in `getterAccessibility / setterAccessibility` → MSBuild switch prefix |

Each escaping fix (env vars in #186, `;` → `%3B` in #187) just exposed the next layer.

## Fix

Stop fighting the command-line parser. The release notes are sourced via env vars (already done in #186) that `Directory.Build.props` now picks up directly as MSBuild properties:

```xml
<PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST' AND '$(RELEASE_NOTES)' != ''">$(RELEASE_NOTES)</PackageReleaseNotes>
<PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST.Json' AND '$(JSON_RELEASE_NOTES)' != ''">$(JSON_RELEASE_NOTES)</PackageReleaseNotes>
<PackageReleaseNotes Condition="'$(MSBuildProjectName)' == 'Fabulous.AST.Build' AND '$(BUILD_RELEASE_NOTES)' != ''">$(BUILD_RELEASE_NOTES)</PackageReleaseNotes>
```

MSBuild auto-imports env vars as properties; `$(RELEASE_NOTES)` evaluates to the raw env-var value with zero parsing between the shell and MSBuild's internal string representation. Drops the `-p:PackageReleaseNotes=...` from each `dotnet pack` invocation.

## Verification

Locally packed `Fabulous.AST.2.0.0-pre07.nupkg` with `RELEASE_NOTES` set to realistic content containing backticks, semicolons (both `net8.0;net10.0` and English clauses), slashes (`A / B`), parens, and newlines. Inspected the resulting `.nuspec` — `<releaseNotes>` contains the content verbatim, no truncation.

## Next step after merge

Move the `2.0.0-pre07` tag forward one more time.
