### PR TITLE
feat: add Verify.parses for round-trip syntactic verification

### DIFF
--- a/extensions/Fabulous.AST.Json/Parsing.fs
+++ b/extensions/Fabulous.AST.Json/Parsing.fs
@@ -137,9 +137,10 @@ module Parsing =
         elif Char.IsDigit(name[0]) then
             "_" + name
         elif fsharpKeywords.Contains(name) || requiresBacktickEscaping name then
-            // Escape any existing backticks by doubling them
-            let escaped = name.Replace("``", "````")
-            "``" + escaped + "``"
+            // A double-backtick-quoted identifier cannot itself contain backticks,
+            // so replace any with underscores before quoting.
+            let safe = name.Replace("`", "_")
+            "``" + safe + "``"
         else
             name
 

--- a/src/Fabulous.AST.Tests/Attributes/Attributes.fs
+++ b/src/Fabulous.AST.Tests/Attributes/Attributes.fs
@@ -16,7 +16,7 @@ module AttributesNodes =
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Obsolete>]
 let x = 12
@@ -30,7 +30,7 @@ let x = 12
                     .attribute(Attribute("Obsolete", ParenExpr(ConstantExpr(String("This is obsolete")))))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Obsolete("This is obsolete")>]
 let x = 12
@@ -44,7 +44,7 @@ let x = 12
                     .attributes([ Attribute("Obsolete", ParenExpr(String("This is obsolete"))) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Obsolete("This is obsolete")>]
 let x = 12
@@ -57,7 +57,7 @@ let x = 12
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).attribute(AttributeTarget("Struct", "return"))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<return: Struct>]
 let x = 12
@@ -78,7 +78,7 @@ let x = 12
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     [<X>]

--- a/src/Fabulous.AST.Tests/Constant.fs
+++ b/src/Fabulous.AST.Tests/Constant.fs
@@ -130,7 +130,7 @@ A
     [<Fact>]
     let ``Basic string escaping``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Hello World")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Hello World"
 
@@ -139,7 +139,7 @@ printfn "Hello World"
     [<Fact>]
     let ``String with newline``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Hello\nWorld")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Hello\nWorld"
 
@@ -148,7 +148,7 @@ printfn "Hello\nWorld"
     [<Fact>]
     let ``String with quotes``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Hello \"World\"")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Hello \"World\""
 """
@@ -156,7 +156,7 @@ printfn "Hello \"World\""
     [<Fact>]
     let ``String with multiple special characters``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Tab\there\rNewline\nQuotes\"'")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Tab\there\rNewline\nQuotes\"\'"
 """
@@ -164,7 +164,7 @@ printfn "Tab\there\rNewline\nQuotes\"\'"
     [<Fact>]
     let ``String with backslashes``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Path\\to\\file")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Path\\to\\file"
 """
@@ -172,7 +172,7 @@ printfn "Path\\to\\file"
     [<Fact>]
     let ``String with Unicode line separators``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Line1\u2028Line2\u2029Line3")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Line1\nLine2 Line3"
 """
@@ -180,7 +180,7 @@ printfn "Line1\nLine2 Line3"
     [<Fact>]
     let ``String with null character``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Start\u0000End")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Start\0End"
 """
@@ -188,7 +188,7 @@ printfn "Start\0End"
     [<Fact>]
     let ``Empty string``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("")) } }
-        |> produces
+        |> producesValid
             """
 printfn ""
 """
@@ -196,7 +196,7 @@ printfn ""
     [<Fact>]
     let ``String with multiple consecutive newlines``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Line1\n\nLine3")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Line1\n\nLine3"
 """
@@ -204,7 +204,7 @@ printfn "Line1\n\nLine3"
     [<Fact>]
     let ``Complex string with mixed special characters and newlines``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Path\\to\n\"file\"\nwith\r\t special\n\\chars")) } }
-        |> produces
+        |> producesValid
             """
 printfn "Path\\to\n\"file\"\nwith\r\t special\n\\chars"
     """
@@ -212,7 +212,7 @@ printfn "Path\\to\n\"file\"\nwith\r\t special\n\\chars"
     [<Fact>]
     let ``Escaped string``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("Hello\n\"World\"")) } }
-        |> produces
+        |> producesValid
             """
     printfn "Hello\n\"World\""
     """
@@ -220,7 +220,7 @@ printfn "Path\\to\n\"file\"\nwith\r\t special\n\\chars"
     [<Fact>]
     let ``String with various edge cases``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("'Start'\u0001\u0002\t\r\n🌟\u001F{0}%s'End'")) } }
-        |> produces
+        |> producesValid
             """
 printfn "\'Start\'\t\r\n🌟{0}%s\'End\'"
     """
@@ -228,7 +228,7 @@ printfn "\'Start\'\t\r\n🌟{0}%s\'End\'"
     [<Fact>]
     let ``String with only special characters``() =
         Oak() { AnonymousModule() { AppExpr("printfn", String("\n\r\t\0")) } }
-        |> produces
+        |> producesValid
             """
 printfn "\n\r\t\\0"
     """

--- a/src/Fabulous.AST.Tests/Core/GenParseTests.fs
+++ b/src/Fabulous.AST.Tests/Core/GenParseTests.fs
@@ -1,0 +1,55 @@
+namespace Fabulous.AST.Tests.Core
+
+open System
+open Fabulous.AST
+open Fantomas.Core.SyntaxOak
+open Xunit
+
+open type Ast
+
+module GenParseTests =
+
+    [<Fact>]
+    let ``widget parses round-trip``() =
+        let widget: WidgetBuilder<Oak> =
+            Oak() {
+                AnonymousModule() {
+                    Value("greet", "x + 1")
+                    TypeDefn("Greeter") { Member("this.Hello", "1") }
+                }
+            }
+
+        Assert.Contains("greet", Gen.parse widget)
+
+    [<Fact>]
+    let ``composed mkOak |> run |> parse pipeline parses``() =
+        let widget: WidgetBuilder<Oak> =
+            Oak() { AnonymousModule() { Value("greet", "x + 1") } }
+
+        Assert.Contains("greet", widget |> Gen.mkOak |> Gen.run |> Gen.parse)
+
+    [<Fact>]
+    let ``valid source string parses and round-trips``() =
+        let source = "let x = 1\nlet y = x + 2\n"
+
+        Assert.Equal(source, Gen.parse source)
+
+    [<Fact>]
+    let ``invalid source string returns located diagnostics, one per OS line``() =
+        let source = "let x = \n  if then else"
+
+        let result = Gen.parse source
+
+        // Diagnostics carry a position and an FS error number...
+        Assert.Contains("Error FS", result)
+        // ...and the multiple diagnostics are separated by the OS newline.
+        Assert.Contains(Environment.NewLine, result)
+
+    [<Fact>]
+    let ``widget producing invalid F# returns located diagnostics``() =
+        // An incomplete expression renders to "let x = if then else", which is
+        // syntactically broken — exactly the kind of codegen bug Gen.parse catches.
+        let widget: WidgetBuilder<Oak> =
+            Oak() { AnonymousModule() { Value("x", "if then else") } }
+
+        Assert.Contains("Error FS", Gen.parse widget)

--- a/src/Fabulous.AST.Tests/Core/TriviaTests.fs
+++ b/src/Fabulous.AST.Tests/Core/TriviaTests.fs
@@ -14,7 +14,7 @@ module TriviaTests =
         Oak() {
             AnonymousModule() { Value("x", ConstantExpr(Int(42)), "int").triviaBefore(SingleLine("This is a comment")) }
         }
-        |> produces
+        |> producesValid
             """
 // This is a comment
 let x: int = 42
@@ -27,7 +27,7 @@ let x: int = 42
                 Value("x", ConstantExpr(Int(42)), "int").triviaAfter(LineCommentAfterSourceCode("This is a comment"))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: int = 42 // This is a comment
 """
@@ -39,7 +39,7 @@ let x: int = 42 // This is a comment
                 Value("x", ConstantExpr(Int(42)), "int").triviaBefore(BlockComment("This is a block comment"))
             }
         }
-        |> produces
+        |> producesValid
             """
 (*This is a block comment*) let x: int = 42
 """
@@ -52,7 +52,7 @@ let x: int = 42 // This is a comment
                     .triviaBefore(BlockComment("This is a block comment", true, true))
             }
         }
-        |> produces
+        |> producesValid
             """
 (*
 This is a block comment
@@ -77,7 +77,7 @@ let x: int = 42
                 Value("y", ConstantExpr(Int(43)), "int")
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: int = 42
 
@@ -93,7 +93,7 @@ let y: int = 43
                     .triviaBefore([ SingleLine("First comment"); SingleLine("Second comment") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 // First comment
 // Second comment
@@ -108,7 +108,7 @@ let x: int = 42
                     .triviaAfter([ LineCommentAfterSourceCode("First comment"); Newline() ])
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: int = 42 // First comment
 
@@ -141,7 +141,7 @@ let
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let (*Block pattern comment*) 42 = "value"
 """
@@ -156,7 +156,7 @@ let (*Block pattern comment*) 42 = "value"
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let 42 = // After pattern
     "value"
@@ -217,7 +217,7 @@ module ExprTriviaTests =
     [<Fact>]
     let ``Expr trivia before with single line comment``() =
         Oak() { AnonymousModule() { Value("x", ConstantExpr(Int(42)).triviaBefore(SingleLine("Expr comment"))) } }
-        |> produces
+        |> producesValid
             """
 let x =
     // Expr comment
@@ -229,7 +229,7 @@ let x =
         Oak() {
             AnonymousModule() { Value("x", ConstantExpr(Int(42)).triviaBefore(BlockComment("Block expr comment"))) }
         }
-        |> produces
+        |> producesValid
             """
 let x = (*Block expr comment*) 42
 """
@@ -241,7 +241,7 @@ let x = (*Block expr comment*) 42
                 Value("x", ConstantExpr(Int(42)).triviaAfter(LineCommentAfterSourceCode("After expr")))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 42 // After expr
 """
@@ -253,7 +253,7 @@ let x = 42 // After expr
                 Value("x", ConstantExpr(Int(42)).triviaBefore([ SingleLine("First"); SingleLine("Second") ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x =
     // First
@@ -268,7 +268,7 @@ let x =
                 Value("x", ConstantExpr(Int(42)).triviaBefore(TriviaNode(SingleLine("TriviaNode comment"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x =
     // TriviaNode comment
@@ -283,7 +283,7 @@ let x =
                 Value("y", ConstantExpr(Int(43)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x =
     42
@@ -304,7 +304,7 @@ let y = 43
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let result =
     // Conditional expression
@@ -320,7 +320,7 @@ module TypeTriviaTests =
                 Value("x", ConstantExpr(Int(42)), LongIdent("int").triviaBefore(SingleLine("Type comment")))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x
     :
@@ -336,7 +336,7 @@ let x
                 Value("x", ConstantExpr(Int(42)), LongIdent("int").triviaBefore(BlockComment("Block type comment")))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: (*Block type comment*) int = 42
 """
@@ -352,7 +352,7 @@ let x: (*Block type comment*) int = 42
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: int // After type
     =
@@ -370,7 +370,7 @@ let x: int // After type
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x
     :
@@ -391,7 +391,7 @@ let x
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x
     :
@@ -409,7 +409,7 @@ module TypeDefnTriviaTests =
                 (Record("Person") { Field("Name", LongIdent("string")) }).triviaBefore(SingleLine("Person record"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Person record
 type Person = { Name: string }
@@ -423,7 +423,7 @@ type Person = { Name: string }
                     .triviaBefore(BlockComment("Block type comment", true, true))
             }
         }
-        |> produces
+        |> producesValid
             """
 (*
 Block type comment
@@ -439,7 +439,7 @@ type Person = { Name: string }
                     .triviaAfter(LineCommentAfterSourceCode("End of Person"))
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person = { Name: string } // End of Person
 """
@@ -452,7 +452,7 @@ type Person = { Name: string } // End of Person
                     .triviaBefore(SingleLine("MyClass definition"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // MyClass definition
 type MyClass() =
@@ -470,7 +470,7 @@ type MyClass() =
                     .triviaBefore(SingleLine("Shape union"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Shape union
 type Shape =
@@ -486,7 +486,7 @@ type Shape =
                     .triviaBefore([ SingleLine("Data record"); SingleLine("More info") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 // Data record
 // More info
@@ -501,7 +501,7 @@ type Data = { Value: int }
                     .triviaBefore(TriviaNode(SingleLine("TriviaNode type def comment")))
             }
         }
-        |> produces
+        |> producesValid
             """
 // TriviaNode type def comment
 type Item = { Id: int }
@@ -518,7 +518,7 @@ type Item = { Id: int }
                     .triviaBefore(SingleLine("Color enum"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Color enum
 type Color =
@@ -538,7 +538,7 @@ module MemberDefnTriviaTests =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     // Value member
@@ -555,7 +555,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     (*Block member comment*) member this.Value = 42
@@ -571,7 +571,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     member this.Value = 42 // End of Value
@@ -587,7 +587,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     // Primary value
@@ -605,7 +605,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     // TriviaNode member comment
@@ -625,7 +625,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     // X coordinate
@@ -643,7 +643,7 @@ module ModuleDeclTriviaTests =
                 (Module("Inner") { Value("x", ConstantExpr(Int(42))) }).triviaBefore(SingleLine("Inner module"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Inner module
 module Inner =
@@ -658,7 +658,7 @@ module Inner =
                     .triviaBefore(BlockComment("Block module comment", true, true))
             }
         }
-        |> produces
+        |> producesValid
             """
 (*
 Block module comment
@@ -675,7 +675,7 @@ module Inner =
                     .triviaAfter(LineCommentAfterSourceCode("End of Inner"))
             }
         }
-        |> produces
+        |> producesValid
             """
 module Inner =
     let x = 42 // End of Inner
@@ -689,7 +689,7 @@ module Inner =
                     .triviaBefore([ SingleLine("Utility functions"); SingleLine("For internal use") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 // Utility functions
 // For internal use
@@ -705,7 +705,7 @@ module Utils =
                     .triviaBefore(TriviaNode(SingleLine("TriviaNode module comment")))
             }
         }
-        |> produces
+        |> producesValid
             """
 // TriviaNode module comment
 module Core =
@@ -715,7 +715,7 @@ module Core =
     [<Fact>]
     let ``Open declaration with trivia``() =
         Oak() { AnonymousModule() { Open("System").triviaBefore(SingleLine("System namespace")) } }
-        |> produces
+        |> producesValid
             """
 // System namespace
 open System
@@ -728,7 +728,7 @@ open System
                 Value("config", ConstantExpr(String("default"))).triviaBefore(SingleLine("Configuration value"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Configuration value
 let config = "default"
@@ -742,7 +742,7 @@ let config = "default"
                     .triviaBefore(SingleLine("Adds two numbers"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Adds two numbers
 let add a b = a + b
@@ -774,7 +774,7 @@ let add a b = a + b
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyType() =
     member this.MyMethod
@@ -803,7 +803,7 @@ module CombinedTriviaTests =
                     .triviaAfter(LineCommentAfterSourceCode("Comment after"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Comment before
 let x = 42 // Comment after
@@ -821,7 +821,7 @@ let x = 42 // Comment after
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let result =
     // The answer
@@ -861,7 +861,7 @@ let
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x
     :
@@ -880,7 +880,7 @@ let x
                     .triviaAfter(LineCommentAfterSourceCode("End of Person"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Person record definition
 type Person = { Name: string } // End of Person
@@ -897,7 +897,7 @@ type Person = { Name: string } // End of Person
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     // Value property
@@ -913,7 +913,7 @@ type MyClass() =
                     .triviaAfter(LineCommentAfterSourceCode("End of Utils"))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Utility module
 module Utils =
@@ -929,7 +929,7 @@ module Utils =
                     .triviaAfter(Directive("#endif"))
             }
         }
-        |> produces
+        |> producesValid
             """
 #if DEBUG
 let debugValue = 42
@@ -945,7 +945,7 @@ let debugValue = 42
                     .triviaAfter([ LineCommentAfterSourceCode("After comment"); Newline() ])
             }
         }
-        |> produces
+        |> producesValid
             """
 // First comment
 // Second comment
@@ -970,7 +970,7 @@ let x = 42 // After comment
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     member this.Process
@@ -993,7 +993,7 @@ module TriviaNodeAfterTests =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let 42 = // After pattern
     "value"
@@ -1025,7 +1025,7 @@ let 42 // Comment
                 Value("x", ConstantExpr(Int(42)).triviaAfter(TriviaNode(LineCommentAfterSourceCode("After expr"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 42 // After expr
 """
@@ -1041,7 +1041,7 @@ let x = 42 // After expr
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x =
     42 // Comment
@@ -1059,7 +1059,7 @@ let x =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x: int // After type
     =
@@ -1081,7 +1081,7 @@ let x: int // After type
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x
     : int // Type comment
@@ -1100,7 +1100,7 @@ let x
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     member this.Value = 42 // After member
@@ -1119,7 +1119,7 @@ type MyClass() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass() =
     member this.Value = 42 // Member comment
@@ -1134,7 +1134,7 @@ type MyClass() =
                     .triviaAfter(TriviaNode(LineCommentAfterSourceCode("End of Person")))
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person = { Name: string } // End of Person
 """
@@ -1150,7 +1150,7 @@ type Person = { Name: string } // End of Person
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person = { Name: string } // Person record
 
@@ -1164,7 +1164,7 @@ type Person = { Name: string } // Person record
                     .triviaAfter(TriviaNode(LineCommentAfterSourceCode("End of Inner")))
             }
         }
-        |> produces
+        |> producesValid
             """
 module Inner =
     let x = 42 // End of Inner
@@ -1181,7 +1181,7 @@ module Inner =
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 module Inner =
     let x = 42 // Module comment
@@ -1197,7 +1197,7 @@ module Inner =
                     .triviaAfter(TriviaNode(LineCommentAfterSourceCode("After comment")))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Before comment
 let x = 42 // After comment

--- a/src/Fabulous.AST.Tests/Expressions/AnonStructRecord.fs
+++ b/src/Fabulous.AST.Tests/Expressions/AnonStructRecord.fs
@@ -19,7 +19,7 @@ module AnonStructRecord =
     [<InlineData("2013", "``2013``")>]
     let ``Produces an AnonStructRecordExpr with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { AnonStructRecordExpr([ RecordFieldExpr(value, ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             $$"""
 
 struct {| {{expected}} = 1 |}
@@ -29,7 +29,7 @@ struct {| {{expected}} = 1 |}
     [<Fact>]
     let ``AnonStructRecordExpr expression``() =
         Oak() { AnonymousModule() { AnonStructRecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             """
 struct {| A = 1 |}
 """
@@ -41,7 +41,7 @@ struct {| A = 1 |}
                 AnonStructRecordExpr(ConstantExpr(Constant "A"), [ RecordFieldExpr("B", ConstantExpr(Int 1)) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 struct {| A with B = 1 |}
 """

--- a/src/Fabulous.AST.Tests/Expressions/App.fs
+++ b/src/Fabulous.AST.Tests/Expressions/App.fs
@@ -16,7 +16,7 @@ module App =
                 Value(ConstantPat(Constant("x")), AppExpr(ConstantExpr(Constant("printfn")), ConstantExpr(String("a"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = printfn "a"

--- a/src/Fabulous.AST.Tests/Expressions/AppSingleParenArg.fs
+++ b/src/Fabulous.AST.Tests/Expressions/AppSingleParenArg.fs
@@ -12,7 +12,7 @@ module AppSingleParenArg =
     [<Fact>]
     let ``AppSingleParenArg expression``() =
         Oak() { AnonymousModule() { AppSingleParenArgExpr("MyClass", ParenExpr(TupleExpr([ "0"; "0"; "0" ]))) } }
-        |> produces
+        |> producesValid
             """
 MyClass (0, 0, 0)
 """

--- a/src/Fabulous.AST.Tests/Expressions/AppWithLambda.fs
+++ b/src/Fabulous.AST.Tests/Expressions/AppWithLambda.fs
@@ -12,7 +12,7 @@ module AppWithLambda =
     [<Fact>]
     let ``AppWithLambda expression``() =
         Oak() { AnonymousModule() { AppWithLambdaExpr(ConstantExpr "c", [ ConstantPat("a") ], ConstantExpr("a")) } }
-        |> produces
+        |> producesValid
             """
 c (fun a -> a)
 """
@@ -20,7 +20,7 @@ c (fun a -> a)
     [<Fact>]
     let ``AppWithLambda expression with strings``() =
         Oak() { AnonymousModule() { AppWithLambdaExpr("c", [ "a" ], "a") } }
-        |> produces
+        |> producesValid
             """
 c (fun a -> a)
 """
@@ -32,7 +32,7 @@ c (fun a -> a)
                 AppWithMatchLambdaExpr(ConstantExpr("c"), [ ConstantExpr("a") ], [ MatchClauseExpr("a", "12") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 c a (function
     | a -> 12)
@@ -41,7 +41,7 @@ c a (function
     [<Fact>]
     let ``AppWithMatchLambdaExpr expression with strings``() =
         Oak() { AnonymousModule() { AppWithMatchLambdaExpr("c", [ "a" ], [ MatchClauseExpr("a", "12") ]) } }
-        |> produces
+        |> producesValid
             """
 c a (function
     | a -> 12)
@@ -58,7 +58,7 @@ c a (function
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 process input (function
     | x -> 42)
@@ -71,7 +71,7 @@ process input (function
                 AppWithMatchLambdaExpr("process", [ ConstantExpr("input") ], MatchClauseExpr("x", Int(42)))
             }
         }
-        |> produces
+        |> producesValid
             """
 process input (function
     | x -> 42)
@@ -80,7 +80,7 @@ process input (function
     [<Fact>]
     let ``AppWithMatchLambdaExpr with single clause - string funcName and string args``() =
         Oak() { AnonymousModule() { AppWithMatchLambdaExpr("process", [ "input" ], MatchClauseExpr("x", Int(42))) } }
-        |> produces
+        |> producesValid
             """
 process input (function
     | x -> 42)

--- a/src/Fabulous.AST.Tests/Expressions/ArrayOrList.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ArrayOrList.fs
@@ -19,7 +19,7 @@ module ArrayOrList =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [| 1; 2; 3 |]
@@ -35,7 +35,7 @@ let x = [| 1; 2; 3 |]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [ 1; 2; 3 ]
@@ -49,7 +49,7 @@ let x = [ 1; 2; 3 ]
                 ListExpr([ TripleNumberIndexRangeExpr("-24.0", "-1.0", "-30.0") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [| -24.0 .. -1.0 .. -30.0 |]
@@ -77,7 +77,7 @@ let x = [ hello; world; ! ]
     [<Fact>]
     let ``Array expression with constant widgets``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ArrayExpr([ Int 1; Int 2; Int 3 ])) } }
-        |> produces
+        |> producesValid
             """
 
 let x = [| 1; 2; 3 |]
@@ -86,7 +86,7 @@ let x = [| 1; 2; 3 |]
     [<Fact>]
     let ``List expression with constant widgets``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ListExpr([ Int 1; Int 2; Int 3 ])) } }
-        |> produces
+        |> producesValid
             """
 
 let x = [ 1; 2; 3 ]
@@ -95,7 +95,7 @@ let x = [ 1; 2; 3 ]
     [<Fact>]
     let ``Empty array expression``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), EmptyArrayExpr()) } }
-        |> produces
+        |> producesValid
             """
 
 let x = [||]
@@ -104,7 +104,7 @@ let x = [||]
     [<Fact>]
     let ``Empty list expression``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), EmptyListExpr()) } }
-        |> produces
+        |> producesValid
             """
 
 let x = []
@@ -124,7 +124,7 @@ let x = []
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [| 1; a; 2 + 3 |]
@@ -144,7 +144,7 @@ let x = [| 1; a; 2 + 3 |]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [ 1; a; 2 + 3 ]
@@ -160,7 +160,7 @@ let x = [ 1; a; 2 + 3 ]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [| 1; [ 2; 3 ] |]
@@ -176,7 +176,7 @@ let x = [| 1; [ 2; 3 ] |]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = [ 1; [| 2; 3 |] ]
@@ -192,7 +192,7 @@ let x = [ 1; [| 2; 3 |] ]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let result = Array.sum [| 1; 2; 3 |]
@@ -208,7 +208,7 @@ let result = Array.sum [| 1; 2; 3 |]
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let result = List.sum [ 1; 2; 3 ]

--- a/src/Fabulous.AST.Tests/Expressions/BasicExprTests.fs
+++ b/src/Fabulous.AST.Tests/Expressions/BasicExprTests.fs
@@ -12,7 +12,7 @@ module BasicExprTests =
     [<Fact>]
     let ``Constant expression``() =
         Oak() { AnonymousModule() { Value("x", ConstantExpr(Int(42))) } }
-        |> produces
+        |> producesValid
             """
 let x = 42
 """
@@ -20,7 +20,7 @@ let x = 42
     [<Fact>]
     let ``Constant expression from string``() =
         Oak() { AnonymousModule() { Value("x", ConstantExpr("42")) } }
-        |> produces
+        |> producesValid
             """
 let x = 42
 """
@@ -28,7 +28,7 @@ let x = 42
     [<Fact>]
     let ``Null expression``() =
         Oak() { AnonymousModule() { Value("x", NullExpr()) } }
-        |> produces
+        |> producesValid
             """
 let x = null
 """
@@ -36,7 +36,7 @@ let x = null
     [<Fact>]
     let ``Unit expression``() =
         Oak() { AnonymousModule() { Value("x", UnitExpr()) } }
-        |> produces
+        |> producesValid
             """
 let x = ()
 """
@@ -44,7 +44,7 @@ let x = ()
     [<Fact>]
     let ``Expression yielded directly to module``() =
         Oak() { AnonymousModule() { ConstantExpr(String("Standalone expression")) } }
-        |> produces
+        |> producesValid
             """
 "Standalone expression"
 """
@@ -52,7 +52,7 @@ let x = ()
     [<Fact>]
     let ``Expression yielded to module declaration collection``() =
         Oak() { Namespace("MyNamespace") { Module("MyModule") { ConstantExpr(String("Module expression")) } } }
-        |> produces
+        |> producesValid
             """
 namespace MyNamespace
 

--- a/src/Fabulous.AST.Tests/Expressions/Chain.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Chain.fs
@@ -36,7 +36,7 @@ module Chain =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 A.B.C(D).E().F(G).[H]
 """

--- a/src/Fabulous.AST.Tests/Expressions/Computation.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Computation.fs
@@ -18,7 +18,7 @@ module Computation =
                 ComputationExpr "12"
             }
         }
-        |> produces
+        |> producesValid
             """
 { "a" }
 { "a" }

--- a/src/Fabulous.AST.Tests/Expressions/Conditionals.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Conditionals.fs
@@ -32,7 +32,7 @@ module IfThen =
             )
 
         Oak() { AnonymousModule() { IfThenExpr(EscapeHatch(ifExp), EscapeHatch(thenExpr)) } }
-        |> produces
+        |> producesValid
             """
 
 if x = 12 then
@@ -78,7 +78,7 @@ if x = 12 then
 
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let res =
@@ -108,7 +108,7 @@ let res3 =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 if x = 12 then
@@ -200,7 +200,7 @@ module IfThenElif =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 if x = 12 then
     ()
@@ -226,7 +226,7 @@ elif x = 11 then
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 if x = 12 then ()
 elif x = 11 then ()
@@ -274,7 +274,7 @@ else ()
             )
 
         Oak() { AnonymousModule() { IfThenElseExpr(EscapeHatch(ifExp), EscapeHatch(thenExpr), EscapeHatch(elseExpr)) } }
-        |> produces
+        |> producesValid
             """
 
     if x = 12 then () else ()
@@ -292,7 +292,7 @@ else ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 if x = 12 then () else ()

--- a/src/Fabulous.AST.Tests/Expressions/Constant.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Constant.fs
@@ -12,7 +12,7 @@ module Constant =
     [<Fact>]
     let ``let value with a ConstantExpr expression with ConstantString``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(String("a"))) } }
-        |> produces
+        |> producesValid
             """
 
 let x = "a"
@@ -25,7 +25,7 @@ let x = "a"
                 Value(ConstantPat(Constant("x")), ConstantExpr(ConstantMeasure(Constant("1.0"), MeasureSingle("cm"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 1.0<cm>
@@ -48,7 +48,7 @@ let x = 1.0<cm>
                 Value("y", ConstantExpr(ConstantMeasure(Constant("1.0"), MeasureSeq([ "cm"; "/"; "m" ]))))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 1.0<cm / m>
@@ -58,7 +58,7 @@ let y = 1.0<cm / m>
     [<Fact>]
     let ``let value with a ConstantExpr expression with ConstantUnit``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(ConstantUnit())) } }
-        |> produces
+        |> producesValid
             """
 
 let x = ()
@@ -79,7 +79,7 @@ let x = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 55.0f<miles * hour>
@@ -97,7 +97,7 @@ let x = 55.0f<miles * hour>
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 55.0f<miles / hour>
@@ -119,7 +119,7 @@ let x = 55.0f<miles / hour>
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 55.0f / 1000.0<g / kg>

--- a/src/Fabulous.AST.Tests/Expressions/DotIndexedGet.fs
+++ b/src/Fabulous.AST.Tests/Expressions/DotIndexedGet.fs
@@ -27,7 +27,7 @@ module DotIndexedGet =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a.[d]
 a.[d]

--- a/src/Fabulous.AST.Tests/Expressions/DotIndexedSet.fs
+++ b/src/Fabulous.AST.Tests/Expressions/DotIndexedSet.fs
@@ -29,7 +29,7 @@ module DotIndexedSet =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a.[c] <- d
 a.[c] <- d

--- a/src/Fabulous.AST.Tests/Expressions/DotLambda.fs
+++ b/src/Fabulous.AST.Tests/Expressions/DotLambda.fs
@@ -12,7 +12,7 @@ module DotLambda =
     [<Fact>]
     let ``let value with a DotLambda expression``() =
         Oak() { AnonymousModule() { DotLambdaExpr(ConstantExpr("x")) } }
-        |> produces
+        |> producesValid
             """
 
 _.x
@@ -26,7 +26,7 @@ _.x
                 DotLambdaExpr(String("x"))
             }
         }
-        |> produces
+        |> producesValid
             """
 _.x
 _."x"
@@ -35,7 +35,7 @@ _."x"
     [<Fact>]
     let ``let value with a DotLambda string``() =
         Oak() { AnonymousModule() { DotLambdaExpr("x") } }
-        |> produces
+        |> producesValid
             """
 _.x
 """

--- a/src/Fabulous.AST.Tests/Expressions/ExplicitConstructorThen.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ExplicitConstructorThen.fs
@@ -26,7 +26,7 @@ module ExplicitConstructorThen =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     new() =

--- a/src/Fabulous.AST.Tests/Expressions/Expr.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Expr.fs
@@ -18,7 +18,7 @@ module Expr =
                     |> List.map ConstantExpr
             }
         }
-        |> produces
+        |> producesValid
             """
 "A"
 "B"

--- a/src/Fabulous.AST.Tests/Expressions/ExprBeginEnd.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ExprBeginEnd.fs
@@ -12,7 +12,7 @@ module ExprBeginEnd =
     [<Fact>]
     let ``let value with a ExplicitConstructorThen expression``() =
         Oak() { AnonymousModule() { BeginEndExpr(ConstantExpr(Constant("x"))) } }
-        |> produces
+        |> producesValid
             """
 
 begin x end
@@ -26,7 +26,7 @@ begin x end
                 BeginEndExpr(Int(10))
             }
         }
-        |> produces
+        |> producesValid
             """
 begin x end
 begin 10 end
@@ -35,7 +35,7 @@ begin 10 end
     [<Fact>]
     let ``let value with a ExprBeginEnd string``() =
         Oak() { AnonymousModule() { BeginEndExpr("x") } }
-        |> produces
+        |> producesValid
             """
 begin x end
 """
@@ -43,7 +43,7 @@ begin x end
     [<Fact>]
     let ``let value with a ExprBeginEnd expression in parenthesis``() =
         Oak() { AnonymousModule() { BeginEndExpr(ParenExpr(ConstantExpr(Constant("x")))) } }
-        |> produces
+        |> producesValid
             """
 begin (x) end
 """

--- a/src/Fabulous.AST.Tests/Expressions/For.fs
+++ b/src/Fabulous.AST.Tests/Expressions/For.fs
@@ -14,7 +14,7 @@ module For =
         Oak() {
             AnonymousModule() { ForToExpr("i", ConstantExpr("1"), ConstantExpr("10"), ConstantExpr(ConstantUnit())) }
         }
-        |> produces
+        |> producesValid
             """
 for i = 1 to 10 do
     ()
@@ -23,7 +23,7 @@ for i = 1 to 10 do
     [<Fact>]
     let ``A simple for...to loop with constant widgets``() =
         Oak() { AnonymousModule() { ForToExpr("i", Int(1), Int(10), ConstantUnit()) } }
-        |> produces
+        |> producesValid
             """
 for i = 1 to 10 do
     ()
@@ -32,7 +32,7 @@ for i = 1 to 10 do
     [<Fact>]
     let ``A simple for...to loop with strings``() =
         Oak() { AnonymousModule() { ForToExpr("i", "1", "10", "()") } }
-        |> produces
+        |> producesValid
             """
 for i = 1 to 10 do
     ()
@@ -45,7 +45,7 @@ for i = 1 to 10 do
                 ForDownToExpr("i", ConstantExpr("1"), ConstantExpr("10"), ConstantExpr(ConstantUnit()))
             }
         }
-        |> produces
+        |> producesValid
             """
 for i = 1 downto 10 do
     ()
@@ -54,7 +54,7 @@ for i = 1 downto 10 do
     [<Fact>]
     let ``A simple for...downto loop with constant widgets``() =
         Oak() { AnonymousModule() { ForDownToExpr("i", Int(1), Int(10), ConstantUnit()) } }
-        |> produces
+        |> producesValid
             """
 for i = 1 downto 10 do
     ()
@@ -63,7 +63,7 @@ for i = 1 downto 10 do
     [<Fact>]
     let ``A simple for...downto loop with strings``() =
         Oak() { AnonymousModule() { ForDownToExpr("i", "1", "10", "()") } }
-        |> produces
+        |> producesValid
             """
 for i = 1 downto 10 do
     ()

--- a/src/Fabulous.AST.Tests/Expressions/ForEach.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ForEach.fs
@@ -16,7 +16,7 @@ module ForEach =
                 ForEachDoExpr(ConstantPat(Constant("i")), ConstantExpr(Constant("0..9")), ConstantExpr(Constant("i")))
             }
         }
-        |> produces
+        |> producesValid
             """
 for i in 0..9 do
     i
@@ -33,7 +33,7 @@ for i in 0..9 do
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 for i in 0..9 do
     i
@@ -68,7 +68,7 @@ for i in 0..9 do
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 for i in 0..9 do
     i |> ignore
@@ -98,7 +98,7 @@ for i in 0..9 do
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 for i in 0..9 do
     printfn ""
@@ -121,7 +121,7 @@ for i in 0..9 do
                 ForEachArrowExpr("i", "0..9", "i")
             }
         }
-        |> produces
+        |> producesValid
             """
 for i in 0..9 -> i
 for i in 0..9 -> i

--- a/src/Fabulous.AST.Tests/Expressions/Idents.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Idents.fs
@@ -17,7 +17,7 @@ module LongIdentSet =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a <- b
 """
@@ -32,7 +32,7 @@ module Ident =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a
 """
@@ -47,7 +47,7 @@ module ParenILEmbedded =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a
 """

--- a/src/Fabulous.AST.Tests/Expressions/IndexFromEnd.fs
+++ b/src/Fabulous.AST.Tests/Expressions/IndexFromEnd.fs
@@ -12,7 +12,7 @@ module IndexFromEnd =
     [<Fact>]
     let ``IndexFromEnd expression``() =
         Oak() { AnonymousModule() { IndexFromEndExpr(ConstantExpr(Int(0))) } }
-        |> produces
+        |> producesValid
             """
 ^0
 """

--- a/src/Fabulous.AST.Tests/Expressions/InfixApp.fs
+++ b/src/Fabulous.AST.Tests/Expressions/InfixApp.fs
@@ -29,7 +29,7 @@ module InfixApp =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a |> b
 a |> b
@@ -53,7 +53,7 @@ a <| b
                 InfixAppExpr(ConstantExpr(Bool(false)), "||", ConstantExpr(Bool(true)))
             }
         }
-        |> produces
+        |> producesValid
             """
 1 + 2
 3 - 4
@@ -91,7 +91,7 @@ false || true
                 InfixAppExpr(Int(6), "^", "2")
             }
         }
-        |> produces
+        |> producesValid
             """
 1 + 2
 x + 2
@@ -130,7 +130,7 @@ a ++ b
                 PipeRightExpr("value", "toString")
             }
         }
-        |> produces
+        |> producesValid
             """
 1 |> 2
 3 |> 4
@@ -169,7 +169,7 @@ value |> toString
                 PipeLeftExpr("toString", "value")
             }
         }
-        |> produces
+        |> producesValid
             """
 1 <| 2
 3 <| 4
@@ -198,7 +198,7 @@ toString <| value
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 (1 + 2) * 3
 format <| x |> print

--- a/src/Fabulous.AST.Tests/Expressions/InheritRecord.fs
+++ b/src/Fabulous.AST.Tests/Expressions/InheritRecord.fs
@@ -36,7 +36,7 @@ module InheritRecord =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 { inherit Foo() }
 { inherit Foo() }

--- a/src/Fabulous.AST.Tests/Expressions/InterpolatedString.fs
+++ b/src/Fabulous.AST.Tests/Expressions/InterpolatedString.fs
@@ -37,7 +37,7 @@ module InterpolatedString =
                 InterpolatedStringExpr([ "12"; "12"; "12" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 $"{12}"
 $"{12}"
@@ -65,7 +65,7 @@ $"{12}{12}{12}"
                 InterpolatedStringExpr([ Expr(FillExpr("12"), 5) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 $"{{12}}"
 $"{{{12}}}"
@@ -133,7 +133,7 @@ $"{{{{{12}}}}}"
 
             }
         }
-        |> produces
+        |> producesValid
             """
 $"%0.3f{System.Math.PI}"
 $"0x%08x{43962}"
@@ -184,7 +184,7 @@ $"{System.DateTime.UtcNow:``yyyy-MM-dd``}"
                 InterpolatedStringExpr([ Text("'{a}'"); Text(" is not a valid number") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 $"This is a test: {12}"
 $"This is a test: {12}"
@@ -237,7 +237,7 @@ $"'{a}' is not a valid number"
                 InterpolatedStringExpr([ Text("'{a}'"); Text(" is not a valid number") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 $"This is a test: {{12}}"
 $"This is a test: {12}"
@@ -510,7 +510,7 @@ $"Multiple {{{{nested}}}} braces with {value}"
                 InterpolatedStringExpr([ Expr(FillExpr(TupleExpr([ "value"; "10" ]), "F2"), 1) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 $"{value, 10}"
 $"{value, -10}"
@@ -567,7 +567,7 @@ $"Conditional: {if condition then "Yes" else "No"}"
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let message1 = $"Hello {name}"
 let message2 = $"Age: {age}"

--- a/src/Fabulous.AST.Tests/Expressions/Lambda.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Lambda.fs
@@ -12,7 +12,7 @@ module Lambda =
     [<Fact>]
     let ``let value with a Lambda expression``() =
         Oak() { AnonymousModule() { LambdaExpr([ "a" ], "a") } }
-        |> produces
+        |> producesValid
             """
 fun a -> a
 """
@@ -20,7 +20,7 @@ fun a -> a
     [<Fact>]
     let ``let value with a Lambda expression with a constant``() =
         Oak() { AnonymousModule() { LambdaExpr([ Constant("a") ], Int(1)) } }
-        |> produces
+        |> producesValid
             """
 fun a -> 1
 """
@@ -28,7 +28,7 @@ fun a -> 1
     [<Fact>]
     let ``let value with a Lambda expression with a constant list``() =
         Oak() { AnonymousModule() { LambdaExpr([ Constant("a"); Constant("b") ], Int(1)) } }
-        |> produces
+        |> producesValid
             """
 fun a b -> 1
 """
@@ -36,7 +36,7 @@ fun a b -> 1
     [<Fact>]
     let ``let value with a Lambda expression with a constant list and a constant``() =
         Oak() { AnonymousModule() { LambdaExpr([ Constant("a"); Constant("b") ], Constant("c")) } }
-        |> produces
+        |> producesValid
             """
 fun a b -> c
 """

--- a/src/Fabulous.AST.Tests/Expressions/Lazy.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Lazy.fs
@@ -12,7 +12,7 @@ module Lazy =
     [<Fact>]
     let ``let value with a lazy expression``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Constant("lazy 12"))) } }
-        |> produces
+        |> producesValid
             """
 
 let x = lazy 12
@@ -27,7 +27,7 @@ let x = lazy 12
                 Value(ConstantPat(Constant("x")), LazyExpr("12"))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = lazy 12
 let x = lazy 12
@@ -37,7 +37,7 @@ let x = lazy 12
     [<Fact>]
     let ``let value with a lazy expression in parenthesis``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), LazyExpr(ParenExpr(ConstantExpr(Int(12))))) } }
-        |> produces
+        |> producesValid
             """
 
 let x = lazy (12)

--- a/src/Fabulous.AST.Tests/Expressions/Match.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Match.fs
@@ -19,7 +19,7 @@ module Match =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 match [ 1; 2 ] with
@@ -33,7 +33,7 @@ match [ 1; 2 ] with
                 MatchExpr(ConstantExpr(Constant("[ 1; 2 ]")), MatchClauseExpr(NamedPat("a"), ConstantExpr(Int(3))))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 match [ 1; 2 ] with
@@ -58,7 +58,7 @@ match [ 1; 2 ] with
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 match value with
 | Member.C.C7b7df1dc arg1 -> failwith "Not implemented"

--- a/src/Fabulous.AST.Tests/Expressions/MatchLambda.fs
+++ b/src/Fabulous.AST.Tests/Expressions/MatchLambda.fs
@@ -12,7 +12,7 @@ module MatchLambda =
     [<Fact>]
     let ``let value with a MatchLambda expression``() =
         Oak() { AnonymousModule() { MatchLambdaExpr([ MatchClauseExpr("a", Int(3)) ]) } }
-        |> produces
+        |> producesValid
             """
 function
 | a -> 3
@@ -21,7 +21,7 @@ function
     [<Fact>]
     let ``MatchLambda with single clause overload``() =
         Oak() { AnonymousModule() { MatchLambdaExpr(MatchClauseExpr("x", Int(42))) } }
-        |> produces
+        |> producesValid
             """
 function
 | x -> 42

--- a/src/Fabulous.AST.Tests/Expressions/NamedComputation.fs
+++ b/src/Fabulous.AST.Tests/Expressions/NamedComputation.fs
@@ -25,7 +25,7 @@ module NamedComputation =
                 NamedComputationExpr("task", "a")
             }
         }
-        |> produces
+        |> producesValid
             """
 task { "a" }
 task { return"a" }
@@ -46,7 +46,7 @@ task { a }
                 SeqExpr([ "1"; "2" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 seq {
     "a"

--- a/src/Fabulous.AST.Tests/Expressions/NamedIndexedPropertySet.fs
+++ b/src/Fabulous.AST.Tests/Expressions/NamedIndexedPropertySet.fs
@@ -27,7 +27,7 @@ module NamedIndexedPropertySet =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 a c <- d
 a c <- d

--- a/src/Fabulous.AST.Tests/Expressions/NestedIndexWithoutDot.fs
+++ b/src/Fabulous.AST.Tests/Expressions/NestedIndexWithoutDot.fs
@@ -26,7 +26,7 @@ module NestedIndexWithoutDot =
                 NestedIndexWithoutDotExpr(Int(1), Constant("c"), IdentExpr("d"))
             }
         }
-        |> produces
+        |> producesValid
             """
 a[c]d
 a[c]d

--- a/src/Fabulous.AST.Tests/Expressions/New.fs
+++ b/src/Fabulous.AST.Tests/Expressions/New.fs
@@ -20,7 +20,7 @@ module New =
                 Value(ConstantPat(Constant("x")), NewExpr("MyType", "12"))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = new MyType 12
@@ -37,7 +37,7 @@ let x = new MyType 12
                 Value(ConstantPat(Constant("x")), NewExpr(LongIdent "MyType", ParenExpr(ConstantExpr(Int(12)))))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = new MyType(12)

--- a/src/Fabulous.AST.Tests/Expressions/ObjExpr.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ObjExpr.fs
@@ -18,7 +18,7 @@ module ObjExpr =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 { new System.Object() with
     member x.ToString() = "F#" }
@@ -67,7 +67,7 @@ module ObjExpr =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 { new System.IFormattable with
     member x.ToString(format: string, provider: System.IFormatProvider) =

--- a/src/Fabulous.AST.Tests/Expressions/OptVar.fs
+++ b/src/Fabulous.AST.Tests/Expressions/OptVar.fs
@@ -12,7 +12,7 @@ module OptVar =
     [<Fact>]
     let ``OptVarExpr with identifier``() =
         Oak() { AnonymousModule() { Value("x", OptVarExpr("myVar")) } }
-        |> produces
+        |> producesValid
             """
 let x = myVar
 """
@@ -20,7 +20,7 @@ let x = myVar
     [<Fact>]
     let ``OptVarExpr with isOptional false``() =
         Oak() { AnonymousModule() { Value("x", OptVarExpr("myVar", false)) } }
-        |> produces
+        |> producesValid
             """
 let x = myVar
 """
@@ -28,7 +28,7 @@ let x = myVar
     [<Fact>]
     let ``OptVarExpr with isOptional true``() =
         Oak() { AnonymousModule() { Value("x", OptVarExpr("myVar", true)) } }
-        |> produces
+        |> producesValid
             """
 let x = ?myVar
 """

--- a/src/Fabulous.AST.Tests/Expressions/Paren.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Paren.fs
@@ -11,7 +11,7 @@ module Paren =
     [<Fact>]
     let ``let value with a expression wrapped parenthesis``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ParenExpr(ConstantExpr(Int(12)))) } }
-        |> produces
+        |> producesValid
             """
 
 let x = (12)

--- a/src/Fabulous.AST.Tests/Expressions/ParenFunctionNameWithStar.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ParenFunctionNameWithStar.fs
@@ -12,7 +12,7 @@ module ParenFunctionNameWithStar =
     [<Fact>]
     let ``ParenFunctionNameWithStar expression``() =
         Oak() { AnonymousModule() { ParenFunctionNameWithStarExpr("a") } }
-        |> produces
+        |> producesValid
             """
 ( a )
 """

--- a/src/Fabulous.AST.Tests/Expressions/ParenLambda.fs
+++ b/src/Fabulous.AST.Tests/Expressions/ParenLambda.fs
@@ -18,7 +18,7 @@ module ParenLambda =
                 ParenLambdaExpr([ Constant("a") ], "a")
             }
         }
-        |> produces
+        |> producesValid
             """
 (fun a -> a)
 (fun a -> a)
@@ -28,7 +28,7 @@ module ParenLambda =
     [<Fact>]
     let ``let value with a ParenLambda expression with a constant``() =
         Oak() { AnonymousModule() { ParenLambdaExpr([ Constant("a") ], Int(1)) } }
-        |> produces
+        |> producesValid
             """
 (fun a -> 1)
 """
@@ -36,7 +36,7 @@ module ParenLambda =
     [<Fact>]
     let ``let value with a ParenLambda expression with a constant list``() =
         Oak() { AnonymousModule() { ParenLambdaExpr([ Constant("a"); Constant("b") ], Int(1)) } }
-        |> produces
+        |> producesValid
             """
 (fun a b -> 1)
 """
@@ -44,7 +44,7 @@ module ParenLambda =
     [<Fact>]
     let ``let value with a ParenLambda expression with a constant list and a constant``() =
         Oak() { AnonymousModule() { ParenLambdaExpr([ Constant("a"); Constant("b") ], Constant("c")) } }
-        |> produces
+        |> producesValid
             """
 (fun a b -> c)
 """

--- a/src/Fabulous.AST.Tests/Expressions/PrefixApp.fs
+++ b/src/Fabulous.AST.Tests/Expressions/PrefixApp.fs
@@ -19,7 +19,7 @@ module PrefixApp =
                 PrefixAppExpr("?getPropertyValue", "--statusBarHeight")
             }
         }
-        |> produces
+        |> producesValid
             """
 ?getPropertyValue --statusBarHeight
 ?getPropertyValue --statusBarHeight

--- a/src/Fabulous.AST.Tests/Expressions/Quoted.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Quoted.fs
@@ -17,7 +17,7 @@ module Quoted =
                 Value(ConstantPat(Constant("x")), QuotedExpr "12")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = <@ 12 @>

--- a/src/Fabulous.AST.Tests/Expressions/Record.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Record.fs
@@ -19,7 +19,7 @@ module RecordExpr =
     [<InlineData("2013", "``2013``")>]
     let ``Produces an AnonRecordExpr with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { AnonRecordExpr([ RecordFieldExpr(value, ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             $$"""
 
 {| {{expected}} = 1 |}
@@ -34,7 +34,7 @@ module RecordExpr =
     [<InlineData(" net6.0 ", "`` net6.0 ``")>]
     let ``Produces an RecordExpr with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { RecordExpr([ RecordFieldExpr(value, ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             $$"""
 
 { {{expected}} = 1 }
@@ -44,7 +44,7 @@ module RecordExpr =
     [<Fact>]
     let ``RecordExpr expression``() =
         Oak() { AnonymousModule() { RecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             """
 { A = 1 }
 """
@@ -54,7 +54,7 @@ module RecordExpr =
         Oak() {
             AnonymousModule() { RecordExpr(ConstantExpr(Constant "A"), [ RecordFieldExpr("B", ConstantExpr(Int 1)) ]) }
         }
-        |> produces
+        |> producesValid
             """
 { A with B = 1 }
 """
@@ -62,7 +62,7 @@ module RecordExpr =
     [<Fact>]
     let ``AnonRecordExpr expression``() =
         Oak() { AnonymousModule() { AnonRecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 1)) ]) } }
-        |> produces
+        |> producesValid
             """
 {| A = 1 |}
 """
@@ -74,7 +74,7 @@ module RecordExpr =
                 AnonRecordExpr(ConstantExpr(Constant "A"), [ RecordFieldExpr("B", ConstantExpr(Int 1)) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 {| A with B = 1 |}
 """

--- a/src/Fabulous.AST.Tests/Expressions/Single.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Single.fs
@@ -29,7 +29,7 @@ module Single =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = a b

--- a/src/Fabulous.AST.Tests/Expressions/StructTuple.fs
+++ b/src/Fabulous.AST.Tests/Expressions/StructTuple.fs
@@ -19,7 +19,7 @@ module StructTuple =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = struct (1, 2, 3)
@@ -35,7 +35,7 @@ let x = struct (1, 2, 3)
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = (struct (1, 2, 3))

--- a/src/Fabulous.AST.Tests/Expressions/TraitCall.fs
+++ b/src/Fabulous.AST.Tests/Expressions/TraitCall.fs
@@ -34,7 +34,7 @@ module TraitCall =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 ((^N): (static member Bar: _ -> _) source)
 ((^N): (static member Bar: _ -> _) source)
@@ -54,7 +54,7 @@ module TraitCall =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 ((^I or ^R): (static member Map: ^I * ^F -> ^R) source, mapping)
 """

--- a/src/Fabulous.AST.Tests/Expressions/TripleNumberIndexRange.fs
+++ b/src/Fabulous.AST.Tests/Expressions/TripleNumberIndexRange.fs
@@ -12,7 +12,7 @@ module TripleNumberIndexRange =
     [<Fact>]
     let ``TripleNumberIndexRange expression``() =
         Oak() { AnonymousModule() { TripleNumberIndexRangeExpr("1", "2", "3") } }
-        |> produces
+        |> producesValid
             """
 1..2..3
 """

--- a/src/Fabulous.AST.Tests/Expressions/TryFinally.fs
+++ b/src/Fabulous.AST.Tests/Expressions/TryFinally.fs
@@ -19,7 +19,7 @@ module TryFinally =
                 TryFinallyExpr(Int(12), FailWithExpr(String("Not implemented")))
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     12
@@ -40,7 +40,7 @@ finally
     [<Fact>]
     let ``TryFinally with Expr value and string finally``() =
         Oak() { AnonymousModule() { TryFinallyExpr(AppExpr("compute", Int(10)), "cleanup()") } }
-        |> produces
+        |> producesValid
             """
 try
     compute 10
@@ -51,7 +51,7 @@ finally
     [<Fact>]
     let ``TryFinally with string value and Constant finally``() =
         Oak() { AnonymousModule() { TryFinallyExpr("compute()", Int(0)) } }
-        |> produces
+        |> producesValid
             """
 try
     compute()

--- a/src/Fabulous.AST.Tests/Expressions/TryWith.fs
+++ b/src/Fabulous.AST.Tests/Expressions/TryWith.fs
@@ -59,7 +59,7 @@ with
                 TryWithExpr("computeValue()", [ MatchClauseExpr("ex", ConstantExpr(Int(-1))) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     compute 10
@@ -91,7 +91,7 @@ with
                 TryWithExpr("computeValue()", "ex", ConstantExpr(Int(-1)))
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     parseInput "input"
@@ -136,7 +136,7 @@ with
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     parseInput "input"
@@ -182,7 +182,7 @@ with
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     try
@@ -214,7 +214,7 @@ with
                 TryWithExpr("computeValue()", MatchClauseExpr("ex", ConstantExpr(Int(-1))))
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     compute 10

--- a/src/Fabulous.AST.Tests/Expressions/TryWithSingleClause.fs
+++ b/src/Fabulous.AST.Tests/Expressions/TryWithSingleClause.fs
@@ -22,7 +22,7 @@ module TryWithSingleClause =
                 TryWithSingleClauseExpr("12", MatchClauseExpr("_", FailWithExpr(String("Not implemented"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 try
     12

--- a/src/Fabulous.AST.Tests/Expressions/Tuple.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Tuple.fs
@@ -19,7 +19,7 @@ module Tuple =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 1, 2, 3
@@ -35,7 +35,7 @@ let x = 1, 2, 3
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = (1, 2, 3)

--- a/src/Fabulous.AST.Tests/Expressions/Typed.fs
+++ b/src/Fabulous.AST.Tests/Expressions/Typed.fs
@@ -17,7 +17,7 @@ module Typed =
                 Value(ConstantPat(Constant("x")), TypedExpr("2", ":", "int"))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 2: int

--- a/src/Fabulous.AST.Tests/Expressions/While.fs
+++ b/src/Fabulous.AST.Tests/Expressions/While.fs
@@ -12,7 +12,7 @@ module While =
     [<Fact>]
     let ``let value with a WhileExpr expression``() =
         Oak() { AnonymousModule() { WhileExpr(ConstantExpr(Bool(true)), ConstantExpr(Int(0))) } }
-        |> produces
+        |> producesValid
             """
 while true do
     0
@@ -28,7 +28,7 @@ while true do
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 while true do
     0 |> ignore
@@ -48,7 +48,7 @@ while true do
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 while true do
     printfn ""
@@ -63,7 +63,7 @@ while true do
                 WhileExpr(ConstantExpr(Bool(true)), CompExprBodyExpr([ "printfn \"\""; "printfn \"\""; "0 |> ignore" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 while true do
     printfn ""
@@ -74,7 +74,7 @@ while true do
     [<Fact>]
     let ``WhileExpr with Constant condition and Expr body``() =
         Oak() { AnonymousModule() { WhileExpr(Bool(true), AppExpr("doSomething", ConstantExpr("()"))) } }
-        |> produces
+        |> producesValid
             """
 while true do
     doSomething ()
@@ -83,7 +83,7 @@ while true do
     [<Fact>]
     let ``WhileExpr with string condition and Expr body``() =
         Oak() { AnonymousModule() { WhileExpr("condition()", AppExpr("doSomething", ConstantExpr("()"))) } }
-        |> produces
+        |> producesValid
             """
 while condition() do
     doSomething ()
@@ -92,7 +92,7 @@ while condition() do
     [<Fact>]
     let ``WhileExpr with Expr condition and Constant body``() =
         Oak() { AnonymousModule() { WhileExpr(AppExpr("shouldContinue", ConstantExpr("()")), Int(0)) } }
-        |> produces
+        |> producesValid
             """
 while shouldContinue () do
     0
@@ -101,7 +101,7 @@ while shouldContinue () do
     [<Fact>]
     let ``WhileExpr with Expr condition and string body``() =
         Oak() { AnonymousModule() { WhileExpr(AppExpr("shouldContinue", ConstantExpr("()")), "processNext()") } }
-        |> produces
+        |> producesValid
             """
 while shouldContinue () do
     processNext()

--- a/src/Fabulous.AST.Tests/Extensions/Json.fs
+++ b/src/Fabulous.AST.Tests/Extensions/Json.fs
@@ -23,7 +23,7 @@ module JsonGeneration =
 
             AnonymousModule() { Json(json) }
         }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -34,7 +34,7 @@ type Root =
     [<Fact>]
     let ``Generates nested records``() =
         Oak() { AnonymousModule() { Json("{ \"user\": { \"name\": \"Alice\" } }") } }
-        |> produces
+        |> producesValid
             """
 
 type User = { name: string }
@@ -45,7 +45,7 @@ type Root = { user: User }
     [<Fact>]
     let ``Generates alias for root array and element record``() =
         Oak() { AnonymousModule() { Json("[ { \"id\": 1 } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { id: int }
@@ -56,7 +56,7 @@ type Root = RootItem list
     [<Fact>]
     let ``Generates alias for root string``() =
         Oak() { AnonymousModule() { Json("\"hello\"") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = string
@@ -72,7 +72,7 @@ type Root = string
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Address = { street: string; zip: string }
@@ -94,7 +94,7 @@ type Root =
     [<Fact>]
     let ``Marks fields optional across array of objects when missing or null``() =
         Oak() { AnonymousModule() { Json("[ { \"id\": 1, \"name\": \"Alice\" }, { \"id\": null } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { id: int option; name: string option }
@@ -118,7 +118,7 @@ type Root = RootItem list
                 Json(json).documentAllowTrailingCommas(true).documentCommentHandling(JsonCommentHandling.Skip)
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Root = { id: int; name: string }
@@ -128,7 +128,7 @@ type Root = { id: int; name: string }
     [<Fact>]
     let ``Parses array with trailing comma when enabled``() =
         Oak() { AnonymousModule() { Json("[1,2,]").documentAllowTrailingCommas(true) } }
-        |> produces
+        |> producesValid
             """
 
 type Root = int list
@@ -149,7 +149,7 @@ type Root = int list
 """
 
         Oak() { AnonymousModule() { Json(json).serializerOptions(ser) } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { id: int }
@@ -159,7 +159,7 @@ type Root = { id: int }
     [<Fact>]
     let ``Overrides root type name via modifier``() =
         Oak() { AnonymousModule() { Json("{ \"id\": 1 }").rootName("Person") } }
-        |> produces
+        |> producesValid
             """
 
 type Person = { id: int }
@@ -169,7 +169,7 @@ type Person = { id: int }
     [<Fact>]
     let ``Falls back to obj list for empty arrays``() =
         Oak() { AnonymousModule() { Json("{ \"items\": [] }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { items: obj list }
@@ -179,7 +179,7 @@ type Root = { items: obj list }
     [<Fact>]
     let ``Array of objects treats differently-cased keys as distinct by default and marks optional``() =
         Oak() { AnonymousModule() { Json("[ { \"ID\": 1 }, { \"id\": 2 } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { ID: int option; id: int option }
@@ -190,7 +190,7 @@ type Root = RootItem list
     [<Fact>]
     let ``Case-insensitive node option does not merge keys but makes both non-optional``() =
         Oak() { AnonymousModule() { Json("[ { \"ID\": 1 }, { \"id\": 2 } ]").nodePropertyNameCaseInsensitive(true) } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { ID: int; id: int }
@@ -314,7 +314,7 @@ type Root = RootItem list
 """
 
         Oak() { AnonymousModule() { Json(json) } }
-        |> produces
+        |> producesValid
             """
 
 type TracingConfig = { Mode: string }
@@ -361,7 +361,7 @@ type Root = { Functions: FunctionsItem list }
     [<Fact>]
     let ``Handles field names starting with digits``() =
         Oak() { AnonymousModule() { Json("{ \"123field\": \"value\", \"1st\": 1 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { _123field: string; _1st: int }
@@ -371,7 +371,7 @@ type Root = { _123field: string; _1st: int }
     [<Fact>]
     let ``Handles large int64 numbers correctly``() =
         Oak() { AnonymousModule() { Json("{ \"bigNum\": 9223372036854775807 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { bigNum: int64 }
@@ -381,7 +381,7 @@ type Root = { bigNum: int64 }
     [<Fact>]
     let ``Handles floating point numbers``() =
         Oak() { AnonymousModule() { Json("{ \"price\": 123.456789012345 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { price: float }
@@ -391,7 +391,7 @@ type Root = { price: float }
     [<Fact>]
     let ``Handles null-only fields as obj option``() =
         Oak() { AnonymousModule() { Json("{ \"data\": null }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { data: obj }
@@ -401,7 +401,7 @@ type Root = { data: obj }
     [<Fact>]
     let ``Handles type name starting with digit in nested object``() =
         Oak() { AnonymousModule() { Json("{ \"123nested\": { \"value\": 1 } }") } }
-        |> produces
+        |> producesValid
             """
 
 type _123nested = { value: int }
@@ -412,7 +412,7 @@ type Root = { _123nested: _123nested }
     [<Fact>]
     let ``Escapes F# reserved keywords in field names``() =
         Oak() { AnonymousModule() { Json("{ \"type\": \"post\", \"module\": \"core\", \"match\": true }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -425,7 +425,7 @@ type Root =
     [<Fact>]
     let ``Handles field names with special characters``() =
         Oak() { AnonymousModule() { Json("{ \"field:name\": 1, \"field}name\": 2, \"field//comment\": 3 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -438,17 +438,17 @@ type Root =
     [<Fact>]
     let ``Handles field names with backticks``() =
         Oak() { AnonymousModule() { Json("{ \"field``name\": 1 }") } }
-        |> produces
+        |> producesValid
             """
 
-type Root = { ``field````name``: int }
+type Root = { ``field__name``: int }
 
 """
 
     [<Fact>]
     let ``Handles field names with spaces``() =
         Oak() { AnonymousModule() { Json("{ \"field name\": 1, \"another field\": 2 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -460,7 +460,7 @@ type Root =
     [<Fact>]
     let ``Normal field names are not wrapped in backticks``() =
         Oak() { AnonymousModule() { Json("{ \"normalName\": 1, \"another_field\": 2 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { normalName: int; another_field: int }

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -139,6 +139,7 @@
         <Compile Include="Specialized\FSharpFeatures.fs" />
         <Compile Include="Specialized\RealWorld.fs" />
         <Compile Include="Specialized\Properties.fs" />
+        <Compile Include="Core\GenParseTests.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
@@ -43,7 +43,7 @@ module AbstractMembers =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     abstract Area: float with get
@@ -78,7 +78,7 @@ type Meh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     [<Obsolete>]
@@ -123,7 +123,7 @@ type Meh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     abstract Area: float with get
@@ -181,7 +181,7 @@ type Meh =
                 |> _.typeParams(PostfixList([ "'other"; "'another" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh<'other, 'another> =
     abstract Area: float with get
@@ -233,7 +233,7 @@ type Meh<'other, 'another> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     inherit IFoo
@@ -273,7 +273,7 @@ type IMeh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     abstract ClientInfo1:
@@ -313,7 +313,7 @@ type IMeh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     abstract ClientInfo1:
@@ -326,357 +326,31 @@ type IMeh =
 """
 
     [<Fact>]
-    let ``Abstract member with public get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Private) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member with plain get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, setterAccessibility = AccessControl.Private) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member with internal get, plain set``() =
-        Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal) } } }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Internal) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member with internal get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal, AccessControl.Internal) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Public) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member with plain get, plain set``() =
+    let ``Abstract member with get, set``() =
         Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true) } } }
-        |> produces
+        |> producesValid
             """
 type X =
     abstract Y: int with get, set
 """
 
     [<Fact>]
-    let ``Abstract member with internal get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal, AccessControl.Public) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, plain set``() =
-        Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public) } } }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, private set``() =
+    let ``Abstract member parameters with get, set``() =
         Oak() {
             AnonymousModule() {
                 TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Private
-                    )
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), false, true, true)
 
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Private
-                    )
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true, true, true)
 
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
-    abstract Add: a: int -> b: int -> int with internal get, private set
-    abstract Add: a: int * b: int -> int with internal get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Private
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Private
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, private set
-    abstract Add: a: int * b: int -> int with public get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Public
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, public set
-    abstract Add: a: int * b: int -> int with public get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Internal
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Internal
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with internal get, internal set
-    abstract Add: a: int * b: int -> int with internal get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Internal
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Internal
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, internal set
-    abstract Add: a: int * b: int -> int with public get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Public
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with internal get, public set
-    abstract Add: a: int * b: int -> int with internal get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, plain set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true, true, true, AccessControl.Public)
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, set
-    abstract Add: a: int * b: int -> int with public get, set
+    abstract Add: a: int -> b: int -> int with get, set
+    abstract Add: a: int * b: int -> int with get, set
 """
 
     [<Fact>]
@@ -691,7 +365,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     static abstract Add: a: int -> b: int -> int
@@ -712,7 +386,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     /// <summary>
@@ -735,7 +409,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     static abstract Area: float with get

--- a/src/Fabulous.AST.Tests/MemberDefinitions/AutoProperty.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AutoProperty.fs
@@ -43,7 +43,7 @@ module AutoProperty =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string, age: int) =
     /// <summary>
@@ -72,7 +72,7 @@ type Person(name: string, age: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X() =
     member val Y: int = 7 with public get, private set
@@ -87,7 +87,7 @@ type X() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X() =
     member val Y: int = 7 with get, private set
@@ -100,7 +100,7 @@ type X() =
                 TypeDefn("X", UnitPat()) { MemberVal("Y", Int(7), Int(), true, true, AccessControl.Internal) }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X() =
     member val Y: int = 7 with internal get, set

--- a/src/Fabulous.AST.Tests/MemberDefinitions/ExplicitConstructor.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/ExplicitConstructor.fs
@@ -40,7 +40,7 @@ module ExplicitConstructor =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     new(x, y, z) as this = { X = x; Y = y; Z = z }
@@ -69,7 +69,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     new() = MyClass (0, 0, 0)
@@ -125,7 +125,7 @@ type MyClass(x0, y0, z0) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     new(x) = MyClass (x, 0, 0)
@@ -159,7 +159,7 @@ type MyClass(x0, y0, z0) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     new(x, y, z) = MyClass (x, 0, 0)
@@ -196,7 +196,7 @@ type MyClass(x0, y0, z0) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     /// This is an explicit constructor.
@@ -229,7 +229,7 @@ type MyClass(x0, y0, z0) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x0, y0, z0) =
     new(x) = MyClass (x, 0, 0)

--- a/src/Fabulous.AST.Tests/MemberDefinitions/Inherit.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/Inherit.fs
@@ -25,7 +25,7 @@ module Inherit =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string) =
     inherit BaseClass()

--- a/src/Fabulous.AST.Tests/MemberDefinitions/InheritConstructor.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/InheritConstructor.fs
@@ -25,7 +25,7 @@ module InheritConstructor =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string) =
     inherit BaseClass()

--- a/src/Fabulous.AST.Tests/MemberDefinitions/Interface.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/Interface.fs
@@ -32,7 +32,7 @@ module InterfaceMembers =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 type IMyInterface =
     abstract GetValue: unit -> string
@@ -73,7 +73,7 @@ type Colors<'other> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type IMyInterface =
@@ -101,7 +101,7 @@ type MyRecord =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     abstract Name: string
@@ -139,7 +139,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IFoo =
     abstract Name: string
@@ -183,7 +183,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMyInterface =
     abstract GetValue: unit -> string

--- a/src/Fabulous.AST.Tests/MemberDefinitions/LetBinding.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/LetBinding.fs
@@ -29,7 +29,7 @@ module LetBinding =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     let mutable _name = ""
@@ -60,7 +60,7 @@ type Person() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     let mutable _name = ""

--- a/src/Fabulous.AST.Tests/MemberDefinitions/MemberDefn.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/MemberDefn.fs
@@ -39,7 +39,7 @@ module MemberDefn =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 type IMyInterface =
     abstract GetValue: unit -> string

--- a/src/Fabulous.AST.Tests/MemberDefinitions/Override.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/Override.fs
@@ -22,7 +22,7 @@ module Override =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Derived() =
     inherit Base()
@@ -40,7 +40,7 @@ type Derived() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Derived() =
     inherit Base()
@@ -58,7 +58,7 @@ type Derived() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Derived() =
     inherit Base()
@@ -76,7 +76,7 @@ type Derived() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Derived() =
     inherit Base()

--- a/src/Fabulous.AST.Tests/MemberDefinitions/PropertyGetSet.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/PropertyGetSet.fs
@@ -131,7 +131,7 @@ module PropertyGetSet =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     member this.Position
@@ -223,7 +223,7 @@ type Person(name: string, age: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     member this.Position

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/AnonymousModule.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/AnonymousModule.fs
@@ -11,7 +11,7 @@ module AnonymousModule =
     [<Fact>]
     let ``Produces a simple hello world console app``() =
         Oak() { AnonymousModule() { AppExpr(ConstantExpr(Constant("printfn")), ConstantExpr(String("hello, world"))) } }
-        |> produces
+        |> producesValid
             """
 
 printfn "hello, world"
@@ -29,7 +29,7 @@ printfn "hello, world"
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 let x = "hello, world"
@@ -46,7 +46,7 @@ printfn "%s" x
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 printfn "%s" 0
@@ -58,7 +58,7 @@ printfn "%s" 2
     [<Fact>]
     let ``AnonymousModule inside of top level module``() =
         Oak() { Namespace("MyModule") { AnonymousModule() { () } } |> _.toImplicit() }
-        |> produces
+        |> producesValid
             """
 module MyModule
 """

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/Exception.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/Exception.fs
@@ -36,7 +36,7 @@ module ExceptionDefn =
                 ExceptionDefn("Error9", [ ("a", "string"); ("b", "int") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 exception Error
 exception Error1 of string
@@ -69,7 +69,7 @@ exception Error9 of a: string * b: int
                       } ]
             }
         }
-        |> produces
+        |> producesValid
             """
 exception Error
 exception Error1 of string

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/ExternalFunctions.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/ExternalFunctions.fs
@@ -12,7 +12,7 @@ module ExternalFunctions =
     [<Fact>]
     let ``Produces an ExternBindingNodeNoParams``() =
         Oak() { AnonymousModule() { ExternBinding(LongIdent("void"), "HelloWorld") } }
-        |> produces
+        |> producesValid
             """
 extern void HelloWorld()
 """
@@ -28,7 +28,7 @@ extern void HelloWorld()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 extern void HelloWorld(string x)
 """
@@ -45,7 +45,7 @@ extern void HelloWorld(string x)
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 extern void HelloWorld(string x, int y)
 """

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/HashDirectives.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/HashDirectives.fs
@@ -23,7 +23,7 @@ module HashDirectives =
                     .attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn "0044"
 open System
@@ -40,7 +40,7 @@ type HEX = { R: int; G: int; B: int }
                 Help(String("List.map"))
             }
         }
-        |> produces
+        |> producesValid
             """
 #help List.map
 #help "List.map"
@@ -61,7 +61,7 @@ type HEX = { R: int; G: int; B: int }
                     .attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn "0044" "0045"
 open System
@@ -85,7 +85,7 @@ type HEX = { R: int; G: int; B: int }
                     .attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn 44 45
 open System
@@ -110,7 +110,7 @@ type HEX = { R: int; G: int; B: int }
                     .attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn "0044"
 #nowarn "0045"
@@ -136,7 +136,7 @@ type HEX = { R: int; G: int; B: int }
                     .attribute(Attribute "Obsolete")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn 44
 #nowarn 45
@@ -162,7 +162,7 @@ type HEX = { R: int; G: int; B: int }
             }
         }
 
-        |> produces
+        |> producesValid
             """
 namespace MyApp
 
@@ -187,7 +187,7 @@ type HEX = { R: int; G: int; B: int }
                 HashDirective("help")
             }
         }
-        |> produces
+        |> producesValid
             """
 #if !DEBUG
 let str = "Not debugging!"
@@ -207,7 +207,7 @@ let str = "Debugging!"
                 Open("System")
             }
         }
-        |> produces
+        |> producesValid
             """
 #nowarn "0044"
 #nowarn "0045"

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/Module.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/Module.fs
@@ -13,7 +13,7 @@ module Module =
     [<Fact>]
     let ``Produces a top level module``() =
         Oak() { Namespace("Fabulous.AST") { Value("x", ConstantExpr(Int(3))) } |> _.toImplicit() }
-        |> produces
+        |> producesValid
             """
 module Fabulous.AST
 
@@ -27,7 +27,7 @@ let x = 3
             |> _.toImplicit()
             |> _.xmlDocs([ "Im a TopLevelModule" ])
         }
-        |> produces
+        |> producesValid
             """
 /// Im a TopLevelModule
 module Fabulous.AST
@@ -42,7 +42,7 @@ let x = 3
             |> _.attribute(Attribute("AutoOpen"))
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 [<AutoOpen>]
 module Fabulous.AST
@@ -58,7 +58,7 @@ let x = 3
             |> _.xmlDocs([ "Im a TopLevelModule" ])
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 /// Im a TopLevelModule
 [<AutoOpen>]
@@ -74,7 +74,7 @@ let x = 3
             |> _.toRecursive()
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 module rec Fabulous.AST
 
@@ -84,7 +84,7 @@ let x = 3
     [<Fact>]
     let ``Produces a top level module with unit``() =
         Oak() { Namespace("Fabulous.AST") { ConstantExpr(ConstantUnit()) } |> _.toImplicit() }
-        |> produces
+        |> producesValid
             """
 module Fabulous.AST
 
@@ -97,7 +97,7 @@ module Fabulous.AST
             Namespace("Fabulous.AST") { Value(ConstantPat(Constant("x")), ConstantExpr(Int(3))) }
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 module Fabulous.AST
 
@@ -132,7 +132,7 @@ let x = 3
             }
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 module Fabulous.AST
 

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/ModuleAbbrev.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/ModuleAbbrev.fs
@@ -13,7 +13,7 @@ module ModuleAbbrev =
     let ``Produces a ModuleAbbrev``() =
         Oak() { AnonymousModule() { ModuleAbbrev("SizeType", "()") } }
 
-        |> produces
+        |> producesValid
             """
 
 module SizeType = ()

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/ModuleDeclAttributes.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/ModuleDeclAttributes.fs
@@ -17,7 +17,7 @@ module ModuleDeclAttributes =
                     .attribute(Attribute "MyCustomModuleAttribute")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<MyCustomModuleAttribute>]
 do printfn "Executing..."
@@ -31,7 +31,7 @@ do printfn "Executing..."
                     .attribute(Attribute "MyCustomModuleAttribute")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<MyCustomModuleAttribute>]
 do printfn "Executing..."
@@ -44,7 +44,7 @@ do printfn "Executing..."
                 ModuleDeclAttribute((" printfn \"Executing...\"")).attribute(Attribute "MyCustomModuleAttribute")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<MyCustomModuleAttribute>]
 do printfn "Executing..."
@@ -59,7 +59,7 @@ do printfn "Executing..."
 
             }
         }
-        |> produces
+        |> producesValid
             """
 [<MyCustomModuleAttribute; MyCustomModuleAttribute2>]
 do printfn "Executing..."

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/Namespace.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/Namespace.fs
@@ -13,7 +13,7 @@ module Namespace =
     [<Fact>]
     let ``Produces a namespace with binding``() =
         Oak() { Namespace("Fabulous.AST") { Value(ConstantPat(Constant("x")), ConstantExpr(Int(3))) } }
-        |> produces
+        |> producesValid
             """
 namespace Fabulous.AST
 
@@ -27,7 +27,7 @@ let x = 3
 
             Namespace("Fabulous.DSL") { Value(ConstantPat(Constant("x")), ConstantExpr(Int(3))) }
         }
-        |> produces
+        |> producesValid
             """
 namespace Fabulous.AST
 
@@ -40,7 +40,7 @@ let x = 3
     [<Fact>]
     let ``Produces a global namespace``() =
         Oak() { GlobalNamespace() { TypeDefn("MyClass", UnitPat()) { Member("this.Prop1", String("X")) } } }
-        |> produces
+        |> producesValid
             """
 namespace global
 
@@ -51,7 +51,7 @@ type MyClass() =
     [<Fact>]
     let ``Produces a rec namespace with binding``() =
         Oak() { (Namespace("Fabulous.AST") { Value(ConstantPat(Constant("x")), ConstantExpr(Int(3))) }).toRecursive() }
-        |> produces
+        |> producesValid
             """
 namespace rec Fabulous.AST
 
@@ -85,7 +85,7 @@ let x = 3
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 namespace Fabulous.AST
 
@@ -124,7 +124,7 @@ let x = 12
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 namespace Fabulous
 
@@ -169,7 +169,7 @@ module AST =
                     EscapeHatch(recordType)
             }
         }
-        |> produces
+        |> producesValid
             """
 namespace Json
 

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/NestedModule.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/NestedModule.fs
@@ -14,7 +14,7 @@ module NestedModule =
     let ``Produces a NestedModule``() =
         Oak() { AnonymousModule() { Module("A") { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))) } } }
 
-        |> produces
+        |> producesValid
             """
 
 module A =
@@ -31,7 +31,7 @@ module A =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 /// I'm a xml comment
@@ -49,7 +49,7 @@ module A =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 [<AutoOpen>]
@@ -91,7 +91,7 @@ module A =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 module A =
@@ -108,7 +108,7 @@ module A =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 module rec A =
@@ -124,7 +124,7 @@ module rec A =
                 |> _.toPrivate()
             }
         }
-        |> produces
+        |> producesValid
             """
 
 module private A =
@@ -140,7 +140,7 @@ module private A =
                 |> _.toInternal()
             }
         }
-        |> produces
+        |> producesValid
             """
 
 module internal A =
@@ -181,7 +181,7 @@ module internal A =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 namespace Fabulous.AST
 
@@ -224,7 +224,7 @@ module Foo =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 namespace Fabulous.AST
 
@@ -246,7 +246,7 @@ module Bar =
                       Module("C") { Value(ConstantPat(Constant("z")), ConstantExpr(Int(3))) } ]
             }
         }
-        |> produces
+        |> producesValid
             """
 module A =
     let x = 1

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/OpenList.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/OpenList.fs
@@ -12,7 +12,7 @@ module Open =
     [<Fact>]
     let ``Produces a simple open directive from a widget``() =
         Oak() { AnonymousModule() { Open("ABC") } }
-        |> produces
+        |> producesValid
             """
 open ABC
 """
@@ -27,7 +27,7 @@ open ABC
             }
 
         }
-        |> produces
+        |> producesValid
             """
 
 open ABC.DEF
@@ -46,7 +46,7 @@ open GHI
             }
 
         }
-        |> produces
+        |> producesValid
             """
 open global.A
 open global.B
@@ -62,7 +62,7 @@ open global.A.B
                 OpenType("GHI")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 open type ABC.DFE
@@ -79,7 +79,7 @@ open type GHI
                 OpenType([ "ABC"; "DFE" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 
 open Fabulous.AST
@@ -90,7 +90,7 @@ open type ABC.DFE
     [<Fact>]
     let ``yield! a list of opens``() =
         Oak() { AnonymousModule() { yield! [ Open("Fabulous.AST"); OpenType([ "ABC"; "DFE" ]) ] } }
-        |> produces
+        |> producesValid
             """
 open Fabulous.AST
 open type ABC.DFE

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Default.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Default.fs
@@ -18,7 +18,7 @@ module Default =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     abstract GetValue: unit -> string
@@ -35,7 +35,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     abstract GetValue: unit -> string
@@ -53,7 +53,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     abstract GetValue: unit -> string

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Function.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Function.fs
@@ -13,7 +13,7 @@ module Function =
         Oak() {
             AnonymousModule() { Function("x", ParameterPat(ConstantPat(Constant "i")), ConstantExpr(ConstantUnit())) }
         }
-        |> produces
+        |> producesValid
             """
 
 let x i = ()
@@ -23,7 +23,7 @@ let x i = ()
     [<Fact>]
     let ``Produces function with summary xml docs``() =
         Oak() { AnonymousModule() { Function("add", [ "a"; "b" ], "a + b").xmlDocs(Summary("This is a comment")) } }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// This is a comment
@@ -34,7 +34,7 @@ let add a b = a + b
     [<Fact>]
     let ``Produces a function with type params``() =
         Oak() { AnonymousModule() { Function("add", [ "a"; "b" ], "a + b").typeParams(PostfixList(TyparDecl("'a"))) } }
-        |> produces
+        |> producesValid
             """
 let add<'a> a b = a + b
 """
@@ -97,7 +97,7 @@ let x i =
                 Function("x", ParameterPat("i"), [ AppExpr("a", "i"); AppExpr("b", "i"); AppExpr("c", "i") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 let x i =
     a i
@@ -124,7 +124,7 @@ let x i =
                 Function("z", [ "i"; "j" ], ConstantExpr(ConstantUnit()))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x i = ()
@@ -146,7 +146,7 @@ let z i j = ()
                 Function("add", "a b", "a + b")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x i = ()
@@ -159,7 +159,7 @@ let add a b = a + b
     [<Fact>]
     let ``Produces a function with single tupled parameter``() =
         Oak() { AnonymousModule() { Function("x", NamedPat("i"), ConstantExpr(ConstantUnit())) } }
-        |> produces
+        |> producesValid
             """
 let x i = ()
 
@@ -168,7 +168,7 @@ let x i = ()
     [<Fact>]
     let ``Produces a function with single parameter``() =
         Oak() { AnonymousModule() { Function("x", ParenPat(NamedPat("i")), ConstantExpr(ConstantUnit())) } }
-        |> produces
+        |> producesValid
             """
 let x (i) = ()
 
@@ -183,7 +183,7 @@ let x (i) = ()
                 Function("x", ParenPat(ParameterPat("i", "int")), ConstantExpr(ConstantUnit()))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x (i: int) = ()
 let x (i: int) = ()
@@ -208,7 +208,7 @@ let x (i: int) = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x (i, j, k) = ()
 
@@ -225,7 +225,7 @@ let x (i, j, k) = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x (i, j, k) = ()
 """
@@ -247,7 +247,7 @@ let x (i, j, k) = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x (i: int, j: string, k) = ()
 """
@@ -267,7 +267,7 @@ let x (i: int, j: string, k) = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x i j k = ()
 
@@ -290,7 +290,7 @@ let x i j k = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x (i: int, j: string, k: bool) = ()
 
@@ -304,7 +304,7 @@ let x (i: int, j: string, k: bool) = ()
                     .attribute(Attribute("Obsolete", ParenExpr(ConstantExpr(String "Use bar instead"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Obsolete("Use bar instead")>]
 let x i = ()
@@ -318,7 +318,7 @@ let x i = ()
                 Function("x", NamedPat("i"), ConstantExpr(ConstantUnit())).xmlDocs([ "Im a function" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 /// Im a function
 let x i = ()
@@ -328,7 +328,7 @@ let x i = ()
     [<Fact>]
     let ``Produces a function with parameters and return type``() =
         Oak() { AnonymousModule() { Function("x", NamedPat("i"), ConstantExpr(ConstantUnit()), Unit()) } }
-        |> produces
+        |> producesValid
             """
 let x i : unit = ()
 
@@ -351,7 +351,7 @@ let x i : unit = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let foo (x: 'T, i: 'U) : unit = ()
 
@@ -360,7 +360,7 @@ let foo (x: 'T, i: 'U) : unit = ()
     [<Fact>]
     let ``Produces an inlined function with parameters``() =
         Oak() { AnonymousModule() { Function("x", NamedPat("i"), ConstantExpr(ConstantUnit())).toInlined() } }
-        |> produces
+        |> producesValid
             """
 
 let inline x i = ()
@@ -370,7 +370,7 @@ let inline x i = ()
     [<Fact>]
     let ``Produces an function with parameters and constant expr ``() =
         Oak() { AnonymousModule() { Function("add", [ ParameterPat("a"); ParameterPat("b") ], Constant("a + b")) } }
-        |> produces
+        |> producesValid
             """
 let add a b = a + b
 """
@@ -386,7 +386,7 @@ let add a b = a + b
                 Function("z", NamedPat("i"), ConstantExpr(ConstantUnit())).toInternal()
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let public x i = ()
@@ -406,7 +406,7 @@ let internal z i = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let cylinderVolume radius length = length * pi * radius * radius
 """
@@ -425,7 +425,7 @@ let cylinderVolume radius length = length * pi * radius * radius
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let cylinderVolume radius =
     let pi = 3.14159
@@ -442,7 +442,7 @@ let cylinderVolume radius =
                       Function("multiply", [ "a"; "b" ], "a * b") ]
             }
         }
-        |> produces
+        |> producesValid
             """
 let add a b = a + b
 let subtract a b = a - b

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Literal.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Literal.fs
@@ -17,7 +17,7 @@ module Literal =
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).attribute(Attribute "Literal")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Literal>]
 let x = 12
@@ -38,7 +38,7 @@ let x = 12
                     Value(ConstantPat(Constant(name)), ConstantExpr(String(value))).attribute(Attribute "Literal")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Literal>]
 let Daisy = "daisy.png"
@@ -63,7 +63,7 @@ let Sunflower = "sunflower.png"
                     .xmlDocs([ "This is a comment" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 /// This is a comment
 [<Literal>]
@@ -78,7 +78,7 @@ let x = 12
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).attribute(Attribute "Literal").toInternal()
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Literal>]
@@ -131,7 +131,7 @@ let internal x = 12
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Literal>]

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Method.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Method.fs
@@ -103,7 +103,7 @@ module MethodMembers =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -143,7 +143,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -172,7 +172,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -197,7 +197,7 @@ type Colors<'other> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -217,7 +217,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -232,7 +232,7 @@ type Colors =
         Oak() {
             AnonymousModule() { TypeDefn("Person", UnitPat()) { Member("this.Name", UnitPat(), ConstantExpr(Int 23)) } }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name() = 23
@@ -251,7 +251,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name(p: string) = 23
@@ -275,7 +275,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name(name: string, age: int) = 23
@@ -295,7 +295,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name (name: string) (age: int) = 23
@@ -308,7 +308,7 @@ type Person() =
                 TypeDefn("Person", UnitPat()) { Member("this.Name", [ "(name: string)"; "(age: int)" ], (Int 23)) }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name (name: string) (age: int) = 23
@@ -646,7 +646,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     static member private GetPrimitiveReader
@@ -716,7 +716,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     [<Obsolete>]
@@ -731,7 +731,7 @@ type Person() =
                 TypeDefn("Person", UnitPat()) { Member("this.Name", UnitPat(), ConstantExpr(Int 23)).toInlined() }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member inline this.Name() = 23
@@ -746,7 +746,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name<'other>() = 23
@@ -761,7 +761,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     | Name
@@ -788,7 +788,7 @@ type Person =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors<'other> =
     | Red of a: string * b: 'other

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Property.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Property.fs
@@ -32,7 +32,7 @@ module PropertyMember =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -73,7 +73,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -99,7 +99,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -119,7 +119,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -145,7 +145,7 @@ type Colors =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -173,7 +173,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -197,7 +197,7 @@ type Colors<'other> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name1 = "name"
@@ -217,7 +217,7 @@ type Person() =
                 |> _.typeParams(PostfixList([ "'other" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person<'other>() =
     member this.Name1 = "name"
@@ -235,7 +235,7 @@ type Person<'other>() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     /// This is a comment
@@ -266,7 +266,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member public this.Name = "name"
@@ -286,7 +286,7 @@ type Person() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name: int = 23
@@ -301,7 +301,7 @@ type Person() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member inline this.Name = "name"
@@ -318,7 +318,7 @@ type Person() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     [<Obsolete>]
@@ -335,7 +335,7 @@ type Person() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     { Name: string }
@@ -356,7 +356,7 @@ type Person =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person<'other> =
     { Name: 'other }
@@ -373,7 +373,7 @@ type Person<'other> =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     | Name
@@ -392,7 +392,7 @@ type Person =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     | Name
@@ -419,7 +419,7 @@ type Person =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors<'other> =
     | Red of a: string * b: 'other
@@ -449,7 +449,7 @@ type Colors<'other> =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors<'other> =
     | Red of a: string * b: 'other
@@ -471,7 +471,7 @@ type Colors<'other> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -490,7 +490,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -509,7 +509,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -528,7 +528,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -547,7 +547,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -566,7 +566,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -585,7 +585,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0
@@ -604,7 +604,7 @@ type Object3D() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Object3D() =
     let mutable _position = 0.0

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/TopLevelBindings/Value.fs
@@ -21,7 +21,7 @@ module Value =
     [<InlineData("some value", "``some value``")>]
     let ``Produces a let binding with auto-escaped identifier`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { Value(value, ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             $$"""
 
 let {{expected}} = 12
@@ -30,7 +30,7 @@ let {{expected}} = 12
     [<Fact>]
     let ``Value with string name and constant auto-escapes identifiers``() =
         Oak() { AnonymousModule() { Value("some value", Int(42)) } }
-        |> produces
+        |> producesValid
             """
 
 let ``some value`` = 42
@@ -47,7 +47,7 @@ let ``some value`` = 42
                 Use(ConstantPat(Constant("x")), Int(12))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 12
@@ -76,7 +76,7 @@ use x = 12
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 namespace Gdmt.Launcher
@@ -96,7 +96,7 @@ module Subcommands =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x, y, z = 1, 2, 3
@@ -113,7 +113,7 @@ let x, y, z = 1, 2, 3
                 Value(ConstantPat(Constant("z")), ConstantExpr(TripleQuotedString(Int(12))))
             }
         }
-        |> produces
+        |> producesValid
             "
 let x: int = 12
 let y = @\"12\"
@@ -141,7 +141,7 @@ let z = \"\"\"12\"\"\"
                 Value(ConstantPat(Constant("c")), ConstantExpr(Int(12)), HashConstraint(LongIdent("int")))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x: int = 12
@@ -156,7 +156,7 @@ let c: #int = 12
     [<Fact>]
     let ``Simple Let binding with an expression``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 
 let x = 12
@@ -173,7 +173,7 @@ let x = 12
                     .typeParams(PostfixList([ TyparDecl("'a"); TyparDecl("'b"); TyparDecl("'c") ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x<'T> = 12
@@ -193,7 +193,7 @@ let x<'a, 'b, 'c> = 12
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).typeParams(PostfixList([ "'a"; "'b"; "'c" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x<'T> = 12
 let x<'a, 'b, 'c> = 12
@@ -203,7 +203,7 @@ let x<'a, 'b, 'c> = 12
     [<Fact>]
     let ``Simple Let private binding``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).toPrivate() } }
-        |> produces
+        |> producesValid
             """
 
 let private x = 12
@@ -213,7 +213,7 @@ let private x = 12
     [<Fact>]
     let ``Simple Let internal binding``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).toInternal() } }
-        |> produces
+        |> producesValid
             """
 
 let internal x = 12
@@ -227,7 +227,7 @@ let internal x = 12
                 Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).xmlDocs([ "This is a comment" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 
 /// This is a comment
@@ -248,7 +248,7 @@ let x = 12
 
             }
         }
-        |> produces
+        |> producesValid
             """
 
 /// This is a fist comment
@@ -266,7 +266,7 @@ let x = 12
 
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Obsolete>]
 let x = 12
@@ -282,7 +282,7 @@ let x = 12
 
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<EditorBrowsable; Obsolete>]
@@ -317,7 +317,7 @@ let x = 12
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 12
@@ -351,7 +351,7 @@ let x = 12
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x = 12
@@ -361,7 +361,7 @@ let x = 12
     [<Fact>]
     let ``Produces a top level mutable let binding``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).toMutable() } }
-        |> produces
+        |> producesValid
             """
 
 let mutable x = 12
@@ -371,7 +371,7 @@ let mutable x = 12
     [<Fact>]
     let ``Produces a top level mutable let binding with return type``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12)), Int()).toMutable() } }
-        |> produces
+        |> producesValid
             """
 
 let mutable x: int = 12
@@ -381,7 +381,7 @@ let mutable x: int = 12
     [<Fact>]
     let ``Produces a top level mutable let binding with an expression``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Constant("x")), ConstantExpr(Int(12))).toMutable() } }
-        |> produces
+        |> producesValid
             """
 
 let mutable x = 12
@@ -397,7 +397,7 @@ let mutable x = 12
                     .typeParams(PostfixList(TyparDecl("'a")))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let inline x<'a> = 12
@@ -431,7 +431,7 @@ let inline x<'a> = 12
                 Value(ConstantPat(Constant("res5")), AppLongIdentAndSingleParenArgExpr([ "conn"; "Open" ], "()"))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let res = conn.Open()
@@ -451,7 +451,7 @@ let res5 = conn.Open ()
                       Value(ConstantPat(Constant("z")), ConstantExpr(Int(3))) ]
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 1
 let y = 2
@@ -465,7 +465,7 @@ let z = 3
     [<Fact>]
     let ``Value(string, WidgetBuilder<Expr>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", ConstantExpr(Int(42))) } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value`` = 42
@@ -475,7 +475,7 @@ let ``my value`` = 42
     [<Fact>]
     let ``Value(string, WidgetBuilder<Expr>, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", ConstantExpr(Int(42)), Int()) } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -485,7 +485,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Value(string, WidgetBuilder<Expr>, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", ConstantExpr(Int(42)), "int") } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -495,7 +495,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Value(string, WidgetBuilder<Constant>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", Int(42)) } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value`` = 42
@@ -505,7 +505,7 @@ let ``my value`` = 42
     [<Fact>]
     let ``Value(string, WidgetBuilder<Constant>, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", Int(42), Int()) } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -515,7 +515,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Value(string, WidgetBuilder<Constant>, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", Int(42), "int") } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -525,7 +525,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Value(string, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", "42") } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value`` = 42
@@ -535,7 +535,7 @@ let ``my value`` = 42
     [<Fact>]
     let ``Value(string, string, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", "42", Int()) } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -545,7 +545,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Value(string, string, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Value("my value", "42", "int") } }
-        |> produces
+        |> producesValid
             """
 
 let ``my value``: int = 42
@@ -555,7 +555,7 @@ let ``my value``: int = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Expr>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", ConstantExpr(Int(42))) } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource`` = 42
@@ -565,7 +565,7 @@ use ``my resource`` = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Expr>, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", ConstantExpr(Int(42)), Int()) } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -575,7 +575,7 @@ use ``my resource``: int = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Expr>, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", ConstantExpr(Int(42)), "int") } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -585,7 +585,7 @@ use ``my resource``: int = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Constant>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", Int(42)) } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource`` = 42
@@ -595,7 +595,7 @@ use ``my resource`` = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Constant>, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", Int(42), Int()) } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -605,7 +605,7 @@ use ``my resource``: int = 42
     [<Fact>]
     let ``Use(string, WidgetBuilder<Constant>, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", Int(42), "int") } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -615,7 +615,7 @@ use ``my resource``: int = 42
     [<Fact>]
     let ``Use(string, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", "42") } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource`` = 42
@@ -625,7 +625,7 @@ use ``my resource`` = 42
     [<Fact>]
     let ``Use(string, string, WidgetBuilder<Type>) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", "42", Int()) } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -635,7 +635,7 @@ use ``my resource``: int = 42
     [<Fact>]
     let ``Use(string, string, string) auto-escapes identifier``() =
         Oak() { AnonymousModule() { Use("my resource", "42", "int") } }
-        |> produces
+        |> producesValid
             """
 
 use ``my resource``: int = 42
@@ -653,7 +653,7 @@ use ``my resource``: int = 42
     [<InlineData("_underscoreName", "_underscoreName")>]
     let ``Value auto-escapes various identifier types`` (input: string) (expected: string) =
         Oak() { AnonymousModule() { Value(input, Int(1)) } }
-        |> produces
+        |> producesValid
             $$"""
 
 let {{expected}} = 1
@@ -669,7 +669,7 @@ let {{expected}} = 1
     [<InlineData("normalResource", "normalResource")>]
     let ``Use auto-escapes various identifier types`` (input: string) (expected: string) =
         Oak() { AnonymousModule() { Use(input, Int(1)) } }
-        |> produces
+        |> producesValid
             $$"""
 
 use {{expected}} = 1

--- a/src/Fabulous.AST.Tests/ModuleDeclarations/Trivia.fs
+++ b/src/Fabulous.AST.Tests/ModuleDeclarations/Trivia.fs
@@ -16,7 +16,7 @@ module Trivia =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 // Comment before
 let x = 10
@@ -29,7 +29,7 @@ let x = 10
                 Value("x", "10").triviaBefore([ SingleLine("Comment before"); SingleLine("Another comment") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 // Comment before
 // Another comment
@@ -39,7 +39,7 @@ let x = 10
     [<Fact>]
     let ``Produces line comment before with a new line before``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaBefore([ Newline(); SingleLine("Comment before") ]) } }
-        |> produces
+        |> producesValid
             """
 
 // Comment before
@@ -49,7 +49,7 @@ let x = 10
     [<Fact>]
     let ``Produces line comment before with a new line after``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaBefore([ SingleLine("Comment before"); Newline() ]) } }
-        |> produces
+        |> producesValid
             """
 // Comment before
 
@@ -61,7 +61,7 @@ let x = 10
         Oak() {
             AnonymousModule() { Value("x", "10").triviaBefore([ Newline(); SingleLine("Comment before"); Newline() ]) }
         }
-        |> produces
+        |> producesValid
             """
 
 // Comment before
@@ -85,7 +85,7 @@ let x =// Comment after source code
     [<Fact>]
     let ``Produces block comment before``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaBefore([ BlockComment("Comment before") ]) } }
-        |> produces
+        |> producesValid
             """
 (*Comment before*) let x = 10
 """
@@ -97,7 +97,7 @@ let x =// Comment after source code
                 Value("x", "10").triviaBefore([ BlockComment("Comment before", newlineBefore = true) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 (*
 Comment before*) let x = 10
@@ -108,7 +108,7 @@ Comment before*) let x = 10
         Oak() {
             AnonymousModule() { Value("x", "10").triviaBefore([ BlockComment("Comment before", newlineAfter = true) ]) }
         }
-        |> produces
+        |> producesValid
             """
 (*Comment before
 *)
@@ -123,7 +123,7 @@ let x = 10
                     .triviaBefore([ BlockComment("Comment before", newlineBefore = true, newlineAfter = true) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 
 (*
@@ -144,7 +144,7 @@ let x = 10
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 (*
@@ -168,7 +168,7 @@ let x = 10
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 (*
@@ -187,7 +187,7 @@ let x = 10
     [<Fact>]
     let ``Produces line comment after``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaAfter([ SingleLine("Comment after") ]) } }
-        |> produces
+        |> producesValid
             """
 let x = 10
 // Comment after
@@ -200,7 +200,7 @@ let x = 10
                 Value("x", "10").triviaAfter([ SingleLine("Comment after"); SingleLine("Another comment") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 // Comment after
@@ -210,7 +210,7 @@ let x = 10
     [<Fact>]
     let ``Produces line comment after with a new line before``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaAfter([ Newline(); SingleLine("Comment after") ]) } }
-        |> produces
+        |> producesValid
             """
 let x = 10
 
@@ -220,7 +220,7 @@ let x = 10
     [<Fact>]
     let ``Produces line comment after with a new line after``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaAfter([ SingleLine("Comment after"); Newline() ]) } }
-        |> produces
+        |> producesValid
             """
 let x = 10
 // Comment after
@@ -232,7 +232,7 @@ let x = 10
         Oak() {
             AnonymousModule() { Value("x", "10").triviaAfter([ Newline(); SingleLine("Comment after"); Newline() ]) }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 
@@ -247,7 +247,7 @@ let x = 10
                 Value("x", "10").triviaAfter([ LineCommentAfterSourceCode("Comment after source code") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10 // Comment after source code
 """
@@ -255,7 +255,7 @@ let x = 10 // Comment after source code
     [<Fact>]
     let ``Produces block comment after``() =
         Oak() { AnonymousModule() { Value("x", "10").triviaAfter([ BlockComment("Comment after") ]) } }
-        |> produces
+        |> producesValid
             """
 let x = 10 (*Comment after*)
 """
@@ -265,7 +265,7 @@ let x = 10 (*Comment after*)
         Oak() {
             AnonymousModule() { Value("x", "10").triviaAfter([ BlockComment("Comment after", newlineBefore = true) ]) }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 (*
@@ -277,7 +277,7 @@ Comment after*)
         Oak() {
             AnonymousModule() { Value("x", "10").triviaAfter([ BlockComment("Comment after", newlineAfter = true) ]) }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10 (*Comment after
 *)
@@ -291,7 +291,7 @@ let x = 10 (*Comment after
                     .triviaAfter([ BlockComment("Comment after", newlineBefore = true, newlineAfter = true) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 (*
@@ -310,7 +310,7 @@ Comment after
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 
@@ -334,7 +334,7 @@ Comment after
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 
@@ -364,7 +364,7 @@ Another comment
                     )
             }
         }
-        |> produces
+        |> producesValid
             """
 let x = 10
 
@@ -397,7 +397,7 @@ Another comment
                     .triviaBefore(Directive("#r \"nuget: Fantomas.Core.SyntaxOak\""))
             }
         }
-        |> produces
+        |> producesValid
             """
 // Comment before
 let x = 1

--- a/src/Fabulous.AST.Tests/Nullness.fs
+++ b/src/Fabulous.AST.Tests/Nullness.fs
@@ -10,7 +10,7 @@ module NullnessTests =
     [<Fact>]
     let ``du case of string or null``() =
         Oak() { AnonymousModule() { Union("DU") { UnionCase("MyCase", Field(Paren(TypeOrNull(String())))) } } }
-        |> produces
+        |> producesValid
             """
 type DU = MyCase of (string | null)
 """
@@ -20,7 +20,7 @@ type DU = MyCase of (string | null)
         Oak() {
             AnonymousModule() { MatchExpr("x", [ MatchClauseExpr(OrPat(IsInstPat(String()), NullPat()), UnitExpr()) ]) }
         }
-        |> produces
+        |> producesValid
             """
 match x with
 | :? string
@@ -35,7 +35,7 @@ match x with
                 |> _.typeParams(PostfixList(TyparDecl("'T"), WhereNotSupportsNull("'T")))
             }
         }
-        |> produces
+        |> producesValid
             """
 type C<'T when 'T: not null> = class end
 """
@@ -51,7 +51,7 @@ type C<'T when 'T: not null> = class end
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let myFunc ("abc" | "": string | null | "123") = 15
 """
@@ -68,7 +68,7 @@ let myFunc ("abc" | "": string | null | "123") = 15
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let myFunc () : 'T when 'T: not struct and 'T: null = null
 """
@@ -80,7 +80,7 @@ let myFunc () : 'T when 'T: not struct and 'T: null = null
                 Function("myFunc", ParenPat(ParameterPat("x", WithGlobal("'T", WhereNotSupportsNull("'T")))), Int(42))
             }
         }
-        |> produces
+        |> producesValid
             """
 let myFunc (x: 'T when 'T: not null) = 42
 """

--- a/src/Fabulous.AST.Tests/Patterns/Ands.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Ands.fs
@@ -18,7 +18,7 @@ module Ands =
                 Value(AndsPat([ "A"; "B" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let A & B = 12

--- a/src/Fabulous.AST.Tests/Patterns/ArrayOrListPat.fs
+++ b/src/Fabulous.AST.Tests/Patterns/ArrayOrListPat.fs
@@ -18,7 +18,7 @@ module ArrayOrListPat =
                 Value(ListPat([ "a"; "b" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let [ a; b ] = 12
@@ -35,7 +35,7 @@ let [ a; b ] = 12
                 Value(ArrayPat([ "a"; "b" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let [| a; b |] = 12
 let [| a; b |] = 12

--- a/src/Fabulous.AST.Tests/Patterns/As.fs
+++ b/src/Fabulous.AST.Tests/Patterns/As.fs
@@ -12,7 +12,7 @@ module As =
     [<Fact>]
     let ``let value with a As pattern``() =
         Oak() { AnonymousModule() { Value(AsPat(NamedPat("A"), NamedPat("B")), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 
 let A as B = 12
@@ -26,7 +26,7 @@ let A as B = 12
                 Value(AsPat("A", "B"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let A as B = 12
 let A as B = 12

--- a/src/Fabulous.AST.Tests/Patterns/BasicPatterns.fs
+++ b/src/Fabulous.AST.Tests/Patterns/BasicPatterns.fs
@@ -12,7 +12,7 @@ module BasicPatterns =
     [<Fact>]
     let ``Constant pattern``() =
         Oak() { AnonymousModule() { Value(ConstantPat(Int(42)), ConstantExpr(String("Forty-two"))) } }
-        |> produces
+        |> producesValid
             """
 let 42 = "Forty-two"
 """
@@ -20,7 +20,7 @@ let 42 = "Forty-two"
     [<Fact>]
     let ``Constant pattern from string``() =
         Oak() { AnonymousModule() { Value(ConstantPat("42"), ConstantExpr(String("Forty-two"))) } }
-        |> produces
+        |> producesValid
             """
 let 42 = "Forty-two"
 """
@@ -28,7 +28,7 @@ let 42 = "Forty-two"
     [<Fact>]
     let ``Null pattern``() =
         Oak() { AnonymousModule() { Value(NullPat(), ConstantExpr(String("Value for null"))) } }
-        |> produces
+        |> producesValid
             """
 let null = "Value for null"
 """
@@ -36,7 +36,7 @@ let null = "Value for null"
     [<Fact>]
     let ``Wildcard pattern``() =
         Oak() { AnonymousModule() { Value(WildPat(), ConstantExpr(String("Wildcard value"))) } }
-        |> produces
+        |> producesValid
             """
 let _ = "Wildcard value"
 """
@@ -44,7 +44,7 @@ let _ = "Wildcard value"
     [<Fact>]
     let ``Unit pattern``() =
         Oak() { AnonymousModule() { Value(UnitPat(), ConstantExpr(String("Unit value"))) } }
-        |> produces
+        |> producesValid
             """
 let () = "Unit value"
 """

--- a/src/Fabulous.AST.Tests/Patterns/ImplicitConstructor.fs
+++ b/src/Fabulous.AST.Tests/Patterns/ImplicitConstructor.fs
@@ -21,7 +21,7 @@ module ImplicitConstructor =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person private (name: string) =
     member this.Name = name
@@ -36,7 +36,7 @@ type Person private (name: string) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person internal (name: string) =
     member this.Name = name
@@ -51,7 +51,7 @@ type Person internal (name: string) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person public (name: string) =
     member this.Name = name
@@ -66,7 +66,7 @@ type Person public (name: string) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string) as self =
     member self.Name = name
@@ -81,7 +81,7 @@ type Person(name: string) as self =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person [<Obsolete>] (name: string) =
     member this.Name = name
@@ -96,7 +96,7 @@ type Person [<Obsolete>] (name: string) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person
     /// Creates a new Person

--- a/src/Fabulous.AST.Tests/Patterns/IsInstPat.fs
+++ b/src/Fabulous.AST.Tests/Patterns/IsInstPat.fs
@@ -16,7 +16,7 @@ module IsInstPat =
                 MatchExpr(ConstantExpr(Int(12)), [ MatchClauseExpr(IsInstPat(String()), ConstantExpr(Int(12))) ])
             }
         }
-        |> produces
+        |> producesValid
             """
 match 12 with
 | :? string -> 12

--- a/src/Fabulous.AST.Tests/Patterns/ListCons.fs
+++ b/src/Fabulous.AST.Tests/Patterns/ListCons.fs
@@ -12,7 +12,7 @@ module ListCons =
     [<Fact>]
     let ``let value with a ListCons pattern``() =
         Oak() { AnonymousModule() { Value(ListConsPat(NamedPat("a"), NamedPat("b")), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let a :: b = 12
 """

--- a/src/Fabulous.AST.Tests/Patterns/LongIdent.fs
+++ b/src/Fabulous.AST.Tests/Patterns/LongIdent.fs
@@ -18,7 +18,7 @@ module LongIdent =
                 Value(LongIdentPat("x", [ "B"; "A" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let x B A = 12
 let x B A = 12
@@ -35,7 +35,7 @@ let x B A = 12
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x<'a, 'b> B A = 12
@@ -44,7 +44,7 @@ let x<'a, 'b> B A = 12
     [<Fact>]
     let ``let value with a LongIdent pattern with private accessibility``() =
         Oak() { AnonymousModule() { Value(LongIdentPat("x", [ NamedPat("a") ]).toPrivate(), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let private x a = 12
 """

--- a/src/Fabulous.AST.Tests/Patterns/NamePatPairs.fs
+++ b/src/Fabulous.AST.Tests/Patterns/NamePatPairs.fs
@@ -24,7 +24,7 @@ module NamePatPairsPat =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x (A = B; B = A) = 12
@@ -42,7 +42,7 @@ let x (A = B; B = A) = 12
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let x<'a, 'b> (A = B; B = A) = 12

--- a/src/Fabulous.AST.Tests/Patterns/NamedParenStarIdent.fs
+++ b/src/Fabulous.AST.Tests/Patterns/NamedParenStarIdent.fs
@@ -12,7 +12,7 @@ module NamedParenStarIdent =
     [<Fact>]
     let ``let value with a NamedParenStarIdent pattern``() =
         Oak() { AnonymousModule() { Value(NamedParenStarIdentPat("a"), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let ( a ) = 12
 """

--- a/src/Fabulous.AST.Tests/Patterns/OptionalVal.fs
+++ b/src/Fabulous.AST.Tests/Patterns/OptionalVal.fs
@@ -12,7 +12,7 @@ module OptionalVal =
     [<Fact>]
     let ``let value with a OptionalVal pattern``() =
         Oak() { AnonymousModule() { Value(OptionalValPat("a"), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let a = 12
 """

--- a/src/Fabulous.AST.Tests/Patterns/Or.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Or.fs
@@ -17,7 +17,7 @@ module Or =
                 Value(OrPat("A", "B"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let A | B = 12
@@ -32,7 +32,7 @@ let A | B = 12
                 Value(OrPat("A", "B"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let A | B = 12

--- a/src/Fabulous.AST.Tests/Patterns/Parameter.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Parameter.fs
@@ -17,7 +17,7 @@ module Parameter =
                 Value("a", ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let a = 12
 let a = 12
@@ -32,7 +32,7 @@ let a = 12
                 Value(ParameterPat("c", "string"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: string = 12
 let b: string = 12
@@ -42,7 +42,7 @@ let c: string = 12
     [<Fact>]
     let ``let value with a Parameter string pattern``() =
         Oak() { AnonymousModule() { Value(ParameterPat(ConstantPat(Constant "a")), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let a = 12
 """
@@ -54,7 +54,7 @@ let a = 12
                 Value(ParameterPat(ConstantPat(Constant("a")), LongIdent "string"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: string = 12
 """
@@ -72,7 +72,7 @@ let a: string = 12
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Class([<Obsolete>] c: int) =
     member this.First([<Obsolete>] a: string) = ()
@@ -95,7 +95,7 @@ type Class([<Obsolete>] c: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Class([<Obsolete>] a: int, [<Required>] b: string) =
     member this.Value = 0
@@ -114,7 +114,7 @@ type Class([<Obsolete>] a: int, [<Required>] b: string) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Class() =
     member this.Second([<A>] a: string -> int) = ()
@@ -132,7 +132,7 @@ type Class() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Class([<Obsolete; Required>] c: int) =
     member this.Value = 0

--- a/src/Fabulous.AST.Tests/Patterns/Paren.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Paren.fs
@@ -18,7 +18,7 @@ module Paren =
                 Value(ParenPat("a"), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let (a) = 12
 let (a) = 12

--- a/src/Fabulous.AST.Tests/Patterns/QuoteExpr.fs
+++ b/src/Fabulous.AST.Tests/Patterns/QuoteExpr.fs
@@ -12,7 +12,7 @@ module QuoteExpr =
     [<Fact>]
     let ``let value with a QuoteExpr pattern``() =
         Oak() { AnonymousModule() { Value(QuoteExprPat(ConstantExpr(Int(345))), ConstantExpr(Int(12))) } }
-        |> produces
+        |> producesValid
             """
 let <@ 345 @> = 12
 """

--- a/src/Fabulous.AST.Tests/Patterns/Record.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Record.fs
@@ -22,7 +22,7 @@ module RecordPat =
                 Value(RecordPat([ RecordFieldPat("B", "4", "x") ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 let { A = "3" } = 12
 let { A = "3" } = 12

--- a/src/Fabulous.AST.Tests/Patterns/StructTuple.fs
+++ b/src/Fabulous.AST.Tests/Patterns/StructTuple.fs
@@ -18,7 +18,7 @@ module StructTuplePat =
                 Value(StructTuplePat([ "a"; "b" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let struct (a, b) = 12

--- a/src/Fabulous.AST.Tests/Patterns/Tuple.fs
+++ b/src/Fabulous.AST.Tests/Patterns/Tuple.fs
@@ -18,7 +18,7 @@ module TuplePat =
                 Value(TuplePat([ "a"; "b" ]), ConstantExpr(Int(12)))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 let a, b = 12

--- a/src/Fabulous.AST.Tests/Specialized/Composition.fs
+++ b/src/Fabulous.AST.Tests/Specialized/Composition.fs
@@ -55,7 +55,7 @@ module Composition =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 /// Shape with measurable area and perimeter.
 type IShape =
@@ -103,7 +103,7 @@ type Circle(radius: float) =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 /// A computation that may fail with a typed error.
 type Result<'T, 'E> =
@@ -150,7 +150,7 @@ let tryDivide x y =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IFormattable =
     abstract Format: unit -> string
@@ -196,7 +196,7 @@ type Person =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 namespace MyApp.Domain
 
@@ -229,7 +229,7 @@ module Money =
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Tree<'a> =
     | Leaf

--- a/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
+++ b/src/Fabulous.AST.Tests/Specialized/FSharpFeatures.fs
@@ -13,7 +13,7 @@ module FSharpFeatures =
     [<Fact>]
     let ``Static abstract member on interface (IWSAM-style)``() =
         Oak() { AnonymousModule() { TypeDefn("IShow") { AbstractMember("Show", [ Unit() ], String()).toStatic() } } }
-        |> produces
+        |> producesValid
             """
 type IShow =
     static abstract Show: unit -> string
@@ -22,7 +22,7 @@ type IShow =
     [<Fact>]
     let ``Static abstract property on interface``() =
         Oak() { AnonymousModule() { TypeDefn("IDefault") { AbstractMember("Default", Int()).toStatic() } } }
-        |> produces
+        |> producesValid
             """
 type IDefault =
     static abstract Default: int
@@ -41,7 +41,7 @@ type IDefault =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let p = struct {| Name = "Edgar"; Age = 42 |}
 """
@@ -55,7 +55,7 @@ let p = struct {| Name = "Edgar"; Age = 42 |}
                 Measure("kg")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Measure>]
 type m
@@ -80,7 +80,7 @@ type kg
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let addPair = fun (a, b) -> a + b
 """
@@ -98,7 +98,7 @@ let addPair = fun (a, b) -> a + b
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let result =
     try
@@ -124,7 +124,7 @@ let result =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type List with
     member this.Second = List.head this.Tail
@@ -148,7 +148,7 @@ type List with
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let go =
     for x in [| 1; 2; 3 |] do

--- a/src/Fabulous.AST.Tests/Specialized/Properties.fs
+++ b/src/Fabulous.AST.Tests/Specialized/Properties.fs
@@ -105,7 +105,7 @@ module Properties =
         Check.QuickThrowOnFailure prop
 
     [<Fact>]
-    let ``Record with N fields produces N field lines``() =
+    let ``Record with N fields producesValid N field lines``() =
         let prop(fieldCount: PositiveInt) =
             let n = min fieldCount.Get 8
 

--- a/src/Fabulous.AST.Tests/Specialized/RealWorld.fs
+++ b/src/Fabulous.AST.Tests/Specialized/RealWorld.fs
@@ -8,7 +8,7 @@ open type Ast
 
 /// Real-world fixture tests — generate complete, realistic F# modules to validate
 /// that the widget API composes well at file-scale, not just per-widget. Each test
-/// produces a substantial chunk of F# code modeled on idiomatic code consumers
+/// producesValid a substantial chunk of F# code modeled on idiomatic code consumers
 /// would actually write.
 module RealWorld =
 
@@ -64,7 +64,7 @@ module RealWorld =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 module Result =
     let map f r =
@@ -122,7 +122,7 @@ module Result =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 namespace Shopping
 
@@ -164,7 +164,7 @@ module Order =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type FileHandle(path: string) =
     member this.Path = path

--- a/src/Fabulous.AST.Tests/TestHelpers.fs
+++ b/src/Fabulous.AST.Tests/TestHelpers.fs
@@ -26,6 +26,13 @@ module TestHelpers =
         let res = Gen.mkOak source |> Gen.run
         Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))
 
+    /// Like <c>produces</c>, but also round-trips the rendered source through the
+    /// parser. When the output is not valid F#, <c>res</c> holds the parser
+    /// diagnostics, so the assertion fails showing them against the expected source.
+    let producesValid (expected: string) (source: WidgetBuilder<#Oak>) =
+        let res = Gen.mkOak source |> Gen.run |> Gen.parse
+        Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))
+
     let producesWithConfig (config: Fantomas.Core.FormatConfig) (expected: string) (source: WidgetBuilder<#Oak>) =
-        let res = Gen.mkOak source |> Gen.runWith config
+        let res = Gen.run(Gen.mkOak source, config)
         Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Abbrev.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Abbrev.fs
@@ -15,7 +15,7 @@ module Abbrev =
     let ``Produces type Abbrev``() =
         Oak() { AnonymousModule() { Abbrev("MyInt", Int()) } }
 
-        |> produces
+        |> producesValid
             """
 
 type MyInt = int
@@ -31,7 +31,7 @@ type MyInt = int
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type SizeType = uint32
@@ -50,7 +50,7 @@ type Transform<'a> = 'a -> 'a
             }
         }
 
-        |> produces
+        |> producesValid
             """
 open System
 
@@ -62,7 +62,7 @@ type MyInt = int
     [<Fact>]
     let ``Produces type Abbrev with xml comments``() =
         Oak() { AnonymousModule() { Abbrev("MyInt", Int()).xmlDocs([ "hello world" ]) } }
-        |> produces
+        |> producesValid
             """
 /// hello world
 type MyInt = int
@@ -72,7 +72,7 @@ type MyInt = int
     [<Fact>]
     let ``Produces type Abbrev with multiple xml comments``() =
         Oak() { AnonymousModule() { Abbrev("MyInt", Int()).xmlDocs([ "First comment"; "Second comment" ]) } }
-        |> produces
+        |> producesValid
             """
 /// First comment
 /// Second comment
@@ -109,7 +109,7 @@ type MyInt = int
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type MyInt = int
@@ -153,7 +153,7 @@ type MyFloat = float
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type MyInt = int
@@ -172,7 +172,7 @@ type MyFloat = float
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Tree = | Leaf
 and Forest = list<Tree>
@@ -188,7 +188,7 @@ and Forest = list<Tree>
                       Abbrev("MyFloat", Float()) ]
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyInt = int
 type MyString = string

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Augmentation.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Augmentation.fs
@@ -17,7 +17,7 @@ module Augmentation =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type DateTime with
     member this.Print = ()
@@ -44,7 +44,7 @@ type DateTime with
                 Function("main", "argv", Constant("0")).attribute(Attribute("EntryPoint"))
             }
         }
-        |> produces
+        |> producesValid
             """
 open Microsoft.FSharp.Core
 
@@ -62,7 +62,7 @@ let main argv = 0
     [<Fact>]
     let ``Produces an augmentation with accessors``() =
         Oak() { AnonymousModule() { Augmentation("A") { Member("this.Y", "this.X") } |> _.toPrivate() } }
-        |> produces
+        |> producesValid
             """
 type private A with
     member this.Y = this.X
@@ -76,7 +76,7 @@ type private A with
                 |> _.xmlDocs([ "This is a test" ])
             }
         }
-        |> produces
+        |> producesValid
             """
 /// This is a test
 type A with
@@ -91,7 +91,7 @@ type A with
                 |> _.attributes([ Attribute("Test") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Test>]
 type A with
@@ -106,7 +106,7 @@ type A with
                 |> _.typeParams(PostfixList(TyparDecl("'T"), ConstraintSingle("'T", "equality")))
             }
         }
-        |> produces
+        |> producesValid
             """
 type A<'T when 'T: equality> with
     member this.Y = this.X
@@ -120,7 +120,7 @@ type A<'T when 'T: equality> with
                 |> _.typeParams(PostfixList(TyparDecl("'T"), ConstraintSingle("'T", "equality")))
             }
         }
-        |> produces
+        |> producesValid
             """
 type A<'T when 'T: equality> with
     member this.Y = this.X
@@ -142,7 +142,7 @@ type A<'T when 'T: equality> with
             }
             |> _.toImplicit()
         }
-        |> produces
+        |> producesValid
             """
 module Extensions
 

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Class.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Class.fs
@@ -18,7 +18,7 @@ module Class =
                 TypeDefn("Person", UnitPat()) { Member(ConstantPat(Constant("this.Name")), EscapeHatch(expr)) }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name = name
@@ -33,7 +33,7 @@ type Person() =
                 TypeDefn("Person", UnitPat()) { Member(ConstantPat(Constant("this.Name")), ConstantExpr(String "")) }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name = ""
@@ -49,7 +49,7 @@ type Person() =
                 |> _.toPrivate()
             }
         }
-        |> produces
+        |> producesValid
             """
 type private Person() =
     member this.Name = ""
@@ -77,7 +77,7 @@ type private Person() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name, lastName, age) =
     member this.Name = name
@@ -103,7 +103,7 @@ type Person(name, lastName, age) =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name, lastName, age) =
     member this.Name = name
@@ -128,7 +128,7 @@ type Person(name, lastName, age) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string, lastName: string, ?age: int) =
     member this.Name = name
@@ -151,7 +151,7 @@ type Person(name: string, lastName: string, ?age: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string, age: int) =
     member this.Name = name
@@ -175,7 +175,7 @@ type Person(name: string, age: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(name: string, age: int) =
     member this.Name = name
@@ -192,7 +192,7 @@ type Person(name: string, age: int) =
                     .attribute(Attribute("Struct"))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Person(name: string) =
@@ -210,7 +210,7 @@ type Person(name: string) =
                     .attribute(Attribute("Struct"))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Person(name: string) =
@@ -228,7 +228,7 @@ type Person(name: string) =
                     .attributes([ Attribute("Sealed"); Attribute("AbstractClass") ])
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Sealed; AbstractClass>]
 type Person() =
@@ -249,7 +249,7 @@ type Person() =
                       } ]
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person() =
     member this.Name = ""
@@ -272,7 +272,7 @@ type Animal() =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(x: int, y: int) =
     do printfn "%d %d" x y
@@ -301,7 +301,7 @@ type MyClass(x: int, y: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person(dataIn: int) =
     let data = dataIn
@@ -320,7 +320,7 @@ module GenericClass =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person<'a, 'b>() =
     member this.Name = ""
@@ -337,7 +337,7 @@ type Person<'a, 'b>() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person<'a, 'b>() =
     member this.Name = ""
@@ -354,7 +354,7 @@ type Person<'a, 'b>() =
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Foo() =
     member this.X = 0
@@ -373,7 +373,7 @@ and Bar() =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Person<'a, 'b>() =

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Delegate.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Delegate.fs
@@ -23,7 +23,7 @@ module Delegate =
                 Delegate("Delegate7", Int(), Int())
             }
         }
-        |> produces
+        |> producesValid
             """
 type Delegate1 = delegate of (int * int) * (int * int) -> int
 type Delegate2 = delegate of (int * int) -> int
@@ -49,7 +49,7 @@ type Delegate7 = delegate of int -> int
                       ) ]
             }
         }
-        |> produces
+        |> producesValid
             """
 type Delegate1 = delegate of (int * int) -> int
 type Delegate2 = delegate of a: (int * int) -> int
@@ -59,7 +59,7 @@ type Delegate3 = delegate of a: int * b: int -> int
     [<Fact>]
     let ``Produces a delegate with attributes``() =
         Oak() { AnonymousModule() { Delegate("Delegate", "int", "int").attributes([ Attribute("Obsolete") ]) } }
-        |> produces
+        |> producesValid
             """
 [<Obsolete>]
 type Delegate = delegate of int -> int
@@ -68,7 +68,7 @@ type Delegate = delegate of int -> int
     [<Fact>]
     let ``Produces a delegate with attribute``() =
         Oak() { AnonymousModule() { Delegate("Delegate", "int", "int").attribute(Attribute("Obsolete")) } }
-        |> produces
+        |> producesValid
             """
 [<Obsolete>]
 type Delegate = delegate of int -> int
@@ -83,7 +83,7 @@ type Delegate = delegate of int -> int
                 Delegate("Delegate3", "int", "int").toInternal()
             }
         }
-        |> produces
+        |> producesValid
             """
 type public Delegate1 = delegate of int -> int
 type private Delegate2 = delegate of int -> int
@@ -93,7 +93,7 @@ type internal Delegate3 = delegate of int -> int
     [<Fact>]
     let ``Produces a delegate with documentation``() =
         Oak() { AnonymousModule() { Delegate("Delegate", "int", "int").xmlDocs([ "This is a delegate" ]) } }
-        |> produces
+        |> producesValid
             """
 /// This is a delegate
 type Delegate = delegate of int -> int
@@ -110,7 +110,7 @@ type Delegate = delegate of int -> int
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyDelegate = delegate of [<ParamArray>] args: string[] -> int
 """

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Enum.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Enum.fs
@@ -22,7 +22,7 @@ module Enum =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -42,7 +42,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -62,7 +62,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -82,7 +82,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -102,7 +102,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -135,7 +135,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -169,7 +169,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -193,7 +193,7 @@ type Colors =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -218,7 +218,7 @@ type Colors =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<FlagsAttribute>]
@@ -243,7 +243,7 @@ type Colors =
                     .attribute(Attribute "FlagsAttribute")
             }
         }
-        |> produces
+        |> producesValid
             """
 [<FlagsAttribute>]
 type Colors =
@@ -268,7 +268,7 @@ type Colors =
                       } ]
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors =
     | Red = 0
@@ -288,7 +288,7 @@ type Sizes =
                 Enum("Colors") { EnumCase("Red", Int(0)) } |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Sizes =
     | Small = 0
@@ -306,7 +306,7 @@ and Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors =
     | Red = 0

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Interface.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Interface.fs
@@ -16,7 +16,7 @@ module Interface =
                 TypeDefn("INumericDotNet") { AbstractMember("Add", [ Int(); Int() ], Int(), true) }
             }
         }
-        |> produces
+        |> producesValid
             """
 type INumericFSharp =
     abstract Add: int -> int -> int
@@ -42,7 +42,7 @@ module GenericInterface =
 
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyInterface<'other, 'another> =
     abstract Add: int -> int -> string -> int

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Measure.fs
@@ -48,7 +48,7 @@ module UnitsOfMeasure =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 /// Cm, centimeters.
@@ -119,7 +119,7 @@ type Ml = cm^3
     [<Fact>]
     let ``Produces type Unit of measure with an extra attribute``() =
         Oak() { AnonymousModule() { Measure("cm").xmlDocs([ "Cm, centimeters." ]).attribute(Attribute("Obsolete")) } }
-        |> produces
+        |> producesValid
             """
 /// Cm, centimeters.
 [<Measure; Obsolete>]
@@ -134,7 +134,7 @@ type cm
                 Measure("s") |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Measure>]
 type m

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
@@ -18,7 +18,7 @@ module Record =
     [<InlineData("2013", "``2013``")>]
     let ``Produces a record with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { Record("Person") { Field(value, LongIdent("int")) } } }
-        |> produces
+        |> producesValid
             $$"""
 
 type Person = { {{expected}}: int }
@@ -36,7 +36,7 @@ type Person = { {{expected}}: int }
                     .attribute(Attribute "Serializable")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Serializable>]
@@ -56,7 +56,7 @@ type Colors = { Red: int; Green: int; Blue: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -80,7 +80,7 @@ type Colors =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -104,7 +104,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Colors<'other> =
@@ -129,7 +129,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 [<Struct; Obsolete>]
 type Colors<'other> =
@@ -157,7 +157,7 @@ type Colors<'other> =
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     { Name: string
@@ -185,7 +185,7 @@ and Address =
 
         [ "G"; "B" ]
         |> generateModel
-        |> produces
+        |> producesValid
             """
 type R = { X: float }
 type G = { X: float }
@@ -197,7 +197,7 @@ type B = { X: float }
         Oak() {
             AnonymousModule() { Record("Color") { yield! [ Field("R", Int()); Field("G", Int()); Field("B", Int()) ] } }
         }
-        |> produces
+        |> producesValid
             """
 type Color = { R: int; G: int; B: int }
 """
@@ -212,9 +212,9 @@ type Color = { R: int; G: int; B: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { private Name: string; Age: int }
+type Person = private { Name: string; Age: int }
 """
 
     [<Fact>]
@@ -227,9 +227,9 @@ type Person = { private Name: string; Age: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { internal Name: string; Age: int }
+type Person = internal { Name: string; Age: int }
 """
 
     [<Fact>]
@@ -242,7 +242,7 @@ type Person = { internal Name: string; Age: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { public Name: string; Age: int }
+type Person = public { Name: string; Age: int }
 """

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Struct.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Struct.fs
@@ -24,7 +24,7 @@ module Struct =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     struct
@@ -50,7 +50,7 @@ type Y =
                 |> _.attribute(Attribute("Struct"))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Struct>]

--- a/src/Fabulous.AST.Tests/TypeDefinitions/TypeDefnExplicit.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/TypeDefnExplicit.fs
@@ -20,7 +20,7 @@ module TypeDefnExplicit =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass = class end
 
@@ -38,7 +38,7 @@ type MyClass3(name: string) =
     [<Fact>]
     let ``Produces a class end with constructor``() =
         Oak() { AnonymousModule() { ClassEnd("MyClass", UnitPat()) { () } } }
-        |> produces
+        |> producesValid
             """
 type MyClass() = class end
             """
@@ -51,7 +51,7 @@ type MyClass() = class end
 
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Sealed; AbstractClass>]
 type MyClass = class end
@@ -66,7 +66,7 @@ type MyClass = class end
 
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Sealed; AbstractClass>]
 type MyClass(name: string) = class end
@@ -81,7 +81,7 @@ type MyClass(name: string) = class end
                     .typeParams(PostfixList([ "'a" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Sealed; AbstractClass>]
 type MyClass<'a>(name: string) = class end
@@ -90,7 +90,7 @@ type MyClass<'a>(name: string) = class end
     [<Fact>]
     let ``Produces a class end with type params``() =
         Oak() { AnonymousModule() { ClassEnd("MyClass") { () } |> _.typeParams(PostfixList([ "'a"; "'b" ])) } }
-        |> produces
+        |> producesValid
             """
 type MyClass<'a, 'b> = class end
             """
@@ -98,7 +98,7 @@ type MyClass<'a, 'b> = class end
     [<Fact>]
     let ``Produces a class end with constructor and  type params``() =
         Oak() { AnonymousModule() { (ClassEnd("MyClass", UnitPat()) { () }).typeParams(PostfixList([ "'a"; "'b" ])) } }
-        |> produces
+        |> producesValid
             """
 type MyClass<'a, 'b>() = class end
             """
@@ -107,7 +107,7 @@ module StructEnd =
     [<Fact>]
     let ``Produces a struct end empty constructor``() =
         Oak() { AnonymousModule() { StructEnd("MyClass", UnitPat()) { () } } }
-        |> produces
+        |> producesValid
             """
 type MyClass() = struct end
             """
@@ -124,7 +124,7 @@ type MyClass() = struct end
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type MyClass(a: string) = struct end
 
@@ -144,7 +144,7 @@ type Y(a: int) =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Point(x: int) =
     struct
@@ -156,7 +156,7 @@ module InterfaceEnd =
     [<Fact>]
     let ``Produces an interface end``() =
         Oak() { AnonymousModule() { InterfaceEnd("IFoo") { () } } }
-        |> produces
+        |> producesValid
             """
 type IFoo = interface end
                     """
@@ -164,7 +164,7 @@ type IFoo = interface end
     [<Fact>]
     let ``Produces an interface with members``() =
         Oak() { AnonymousModule() { InterfaceEnd("IMarker") { AbstractMember("Name", String()) } } }
-        |> produces
+        |> producesValid
             """
 type IMarker =
     interface

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Union.fs
@@ -20,7 +20,7 @@ module Union =
     [<InlineData("2013", "``2013``")>]
     let ``Produces an union with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { Union("Colors") { UnionCase(value) } } }
-        |> produces
+        |> producesValid
             $$"""
 
 type Colors = | {{expected}}
@@ -40,7 +40,7 @@ type Colors = | {{expected}}
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -63,7 +63,7 @@ type Colors =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 type Option<'a> =
     | Some of 'a
@@ -94,7 +94,7 @@ type Option<'a> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMyInterface =
     abstract GetValue: unit -> string
@@ -126,7 +126,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Shape =
     | Rectangle of float * float
@@ -153,7 +153,7 @@ type Shape =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -190,7 +190,7 @@ type Colors =
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -218,7 +218,7 @@ and Shapes =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -242,7 +242,7 @@ type Colors =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -257,7 +257,7 @@ type Colors =
     [<Fact>]
     let ``Produces an union with attribute``() =
         Oak() { AnonymousModule() { (Union("Colors") { UnionCase("Red") }).attribute(Attribute "Test") } }
-        |> produces
+        |> producesValid
             """
 
 [<Test>]
@@ -272,7 +272,7 @@ type Colors = | Red
                     .attribute(Attribute "Test")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Test>]
@@ -294,7 +294,7 @@ type Colors = | [<Obsolete; Test>] Red
                       } ]
             }
         }
-        |> produces
+        |> producesValid
             """
 type Colors =
     | Red
@@ -310,7 +310,7 @@ type Shapes =
         Oak() {
             AnonymousModule() { Union("Colors") { yield! [ UnionCase("Red"); UnionCase("Green"); UnionCase("Blue") ] } }
         }
-        |> produces
+        |> producesValid
             """
 type Colors =
     | Red
@@ -334,7 +334,7 @@ module GenericUnion =
                 |> _.typeParams(PostfixList([ "'other" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -367,7 +367,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 type IMyInterface =
     abstract GetValue: unit -> string
@@ -400,7 +400,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Colors<'other> =

--- a/src/Fabulous.AST.Tests/Types/LongIdent.fs
+++ b/src/Fabulous.AST.Tests/Types/LongIdent.fs
@@ -14,7 +14,7 @@ module LongIdent =
         Oak() {
             AnonymousModule() { Value("x", UnitExpr(), LongIdent([ "System"; "Collections"; "Generic"; "List" ])) }
         }
-        |> produces
+        |> producesValid
             """
 let x: System.Collections.Generic.List = ()
 """
@@ -22,7 +22,7 @@ let x: System.Collections.Generic.List = ()
     [<Fact>]
     let ``Long identifier with single part``() =
         Oak() { AnonymousModule() { Value("x", UnitExpr(), LongIdent("int")) } }
-        |> produces
+        |> producesValid
             """
 let x: int = ()
 """
@@ -57,7 +57,7 @@ let x: int = ()
                 Value("x", UnitExpr(), Null())
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: bool = ()
 let b: byte = ()

--- a/src/Fabulous.AST.Tests/Types/Measures.fs
+++ b/src/Fabulous.AST.Tests/Types/Measures.fs
@@ -11,7 +11,7 @@ module Measures =
     [<Fact>]
     let ``Basic measure``() =
         Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Constant("1.0"), MeasureSingle("cm"))) } }
-        |> produces
+        |> producesValid
             """
 1.0<cm>
 """
@@ -19,7 +19,7 @@ module Measures =
     [<Fact>]
     let ``Integer with measure``() =
         Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Int(42), MeasureSingle("kg"))) } }
-        |> produces
+        |> producesValid
             """
 42<kg>
 """
@@ -27,7 +27,7 @@ module Measures =
     [<Fact>]
     let ``Float with measure``() =
         Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Float(3.14), MeasureSingle("rad"))) } }
-        |> produces
+        |> producesValid
             """
 3.14<rad>
 """
@@ -43,7 +43,7 @@ module Measures =
     [<Fact>]
     let ``Measure division``() =
         Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Float(55.0), MeasureDivide("km", "h"))) } }
-        |> produces
+        |> producesValid
             """
 55.0<km / h>
 """
@@ -51,7 +51,7 @@ module Measures =
     [<Fact>]
     let ``Measure multiplication (operator)``() =
         Oak() { AnonymousModule() { ConstantExpr(ConstantMeasure(Int(10), MeasureOperator("*", "N", "m"))) } }
-        |> produces
+        |> producesValid
             """
 10<N * m>
 """
@@ -63,7 +63,7 @@ module Measures =
                 ConstantExpr(ConstantMeasure(Double(42.0), MeasureSeq([ "kg"; "*"; "m"; "/"; "s"; "^"; "2" ])))
             }
         }
-        |> produces
+        |> producesValid
             """
 42.0<kg * m / s ^ 2>
 """
@@ -75,7 +75,7 @@ module Measures =
                 ConstantExpr(ConstantMeasure(Float(100.0), MeasurePower(MeasureSingle("m"), Integer("2"))))
             }
         }
-        |> produces
+        |> producesValid
             """
 100.0<m^2>
 """
@@ -87,7 +87,7 @@ module Measures =
                 ConstantExpr(ConstantMeasure(Float(10.0), MeasureSeq([ MeasurePower("s", Negate(Integer("1"))) ])))
             }
         }
-        |> produces
+        |> producesValid
             """
 10.0<s^-1>
 """
@@ -97,7 +97,7 @@ module Measures =
         Oak() {
             AnonymousModule() { ConstantExpr(ConstantMeasure(Float(2.0), MeasurePower("L", Rational("1", "/", "2")))) }
         }
-        |> produces
+        |> producesValid
             """
 2.0<L^(1/2)>
 """
@@ -111,7 +111,7 @@ module Measures =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 5.0<(J / K)>
 """
@@ -147,7 +147,7 @@ module Measures =
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Measure>]
 type m
@@ -181,7 +181,7 @@ let acceleration: float<m / s^2> = 9.81<m / s^2>
                 Value("minutesFromSeconds", InfixAppExpr("seconds", "/", Float(60.0)), AppPrefix(Float(), "min"))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Measure>]
 type s
@@ -221,7 +221,7 @@ let minutesFromSeconds: float<min> = seconds / 60.0
                 Value("force", InfixAppExpr("mass", "*", "acceleration"), AppPrefix(Float(), "N"))
             }
         }
-        |> produces
+        |> producesValid
             """
 [<Measure>]
 type m

--- a/src/Fabulous.AST.Tests/Types/Types.fs
+++ b/src/Fabulous.AST.Tests/Types/Types.fs
@@ -72,7 +72,7 @@ module Types =
                 Value(ConstantPat(Constant "t"), ConstantExpr(Constant "obj"), Obj())
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: bool = false
 let b: byte = 0uy
@@ -198,7 +198,7 @@ let c: int -> string = false
 
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: string option = false
 let b: string option = false
@@ -273,7 +273,7 @@ let n: string[][] = false
                 Value(ConstantPat(Constant("v")), ConstantExpr(Bool(false)), TaskPrefix(String()))
             }
         }
-        |> produces
+        |> producesValid
             """
 let a: option<string> = false
 let b: option<string> = false
@@ -429,7 +429,7 @@ let v: Task<string> = false
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 type Class1<'T when 'T :> System.Exception> = class end
 type Class11<'T when 'T :> System.Exception> = class end
@@ -476,7 +476,7 @@ type Class14<'T, 'U when 'T: equality and 'U: equality> = class end
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let test (env: 't & #System.Numerics.INumber<'t> & #IEquatable<'t>) = ()
 """
@@ -497,7 +497,7 @@ let test (env: 't & #System.Numerics.INumber<'t> & #IEquatable<'t>) = ()
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 let test (env: #ILogger1: #ILogger2) = ()
 """

--- a/src/Fabulous.AST.Tests/XmlDocs.fs
+++ b/src/Fabulous.AST.Tests/XmlDocs.fs
@@ -22,7 +22,7 @@ module XmlDocs =
                     .xmlDocs(Summary("Calculate the volume of a cylinder."))
             }
         }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// Calculate the volume of a cylinder.
@@ -54,7 +54,7 @@ let cylinderVolume radius length =
                     .xmlDocs(xmlDocs)
             }
         }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// Calculate the volume of a cylinder.
@@ -92,7 +92,7 @@ let cylinderVolume radius length =
                     .xmlDocs(xmlDocs)
             }
         }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// Calculate the volume of a cylinder.
@@ -133,7 +133,7 @@ let cylinderVolume radius length =
                     .xmlDocs(xmlDocs)
             }
         }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// Calculate the volume of a cylinder.
@@ -176,7 +176,7 @@ let cylinderVolume radius length =
                     .xmlDocs(xmlDocs)
             }
         }
-        |> produces
+        |> producesValid
             """
 /// <summary>
 /// Calculate the volume of a cylinder.

--- a/src/Fabulous.AST/Widgets/Common.fs
+++ b/src/Fabulous.AST/Widgets/Common.fs
@@ -103,20 +103,87 @@ module Seq =
         coll.Close()
 
 open Fantomas.Core
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Parse
 
-/// It takes the root of the widget tree and create the corresponding Fantomas node, and recursively creating all children nodes
-module Gen =
-    let mkOak(root: WidgetBuilder<'node>) : 'node =
+/// <summary>
+/// Renders a widget tree to F# source and verifies the result. <c>mkOak</c> turns
+/// the root widget into a Fantomas node (recursively building its children),
+/// <c>run</c> formats that node to source (optionally with a config), and <c>parse</c> round-trips
+/// the source back through the parser to confirm it is syntactically valid.
+/// Designed for pipeline use, e.g. <c>widget |> Gen.parse</c> or
+/// <c>widget |> Gen.mkOak |> Gen.run |> Gen.parse</c>.
+/// </summary>
+[<AbstractClass; Sealed>]
+type Gen =
+    /// Builds the Fantomas node for <paramref name="root"/>, recursively creating all children nodes.
+    static member mkOak(root: WidgetBuilder<'node>) : 'node =
         let widget = root.Compile()
         let definition = WidgetDefinitionStore.get widget.Key
         definition.CreateView widget |> unbox
 
-    let run oak =
+    /// Formats <paramref name="oak"/> to F# source using the default config.
+    static member run(oak: Oak) : string =
         CodeFormatter.FormatOakAsync(oak, FormatConfig.Default)
         |> Async.RunSynchronously
 
-    let runWith config oak =
+    /// Formats <paramref name="oak"/> to F# source using <paramref name="config"/>.
+    static member run(oak: Oak, config: FormatConfig) : string =
         CodeFormatter.FormatOakAsync(oak, config) |> Async.RunSynchronously
+
+    /// Renders a single parser diagnostic as
+    /// "(startLine,startCol)-(endLine,endCol) Severity FSxxxx: message".
+    static member private formatDiagnostic(diagnostic: FSharpParserDiagnostic) : string =
+        let position =
+            match diagnostic.Range with
+            | Some range -> $"(%d{range.StartLine},%d{range.StartColumn})-(%d{range.EndLine},%d{range.EndColumn}) "
+            | None -> ""
+
+        let number =
+            match diagnostic.ErrorNumber with
+            | Some n -> $" FS%04d{n}"
+            | None -> ""
+
+        $"%s{position}%A{diagnostic.Severity}%s{number}: %s{diagnostic.Message}"
+
+    /// <summary>
+    /// Parses <paramref name="source"/> with Fantomas's F# parser. Returns the
+    /// source unchanged when syntactically valid, otherwise the formatted error
+    /// diagnostics separated by the OS newline. Does not type-check — for that,
+    /// run the real compiler against the written files.
+    /// </summary>
+    static member parse(source: string) : string =
+        // parseFile gives the parser diagnostics directly (CodeFormatter's
+        // ParseOakAsync throws ParseException on errors instead). We parse with
+        // no conditional-compilation defines, so syntax inside inactive #if
+        // branches is not checked — that matches the empty-defines parse that
+        // ParseOakAsync surfaces first.
+        try
+            let _, diagnostics = parseFile false (SourceText.ofString source) []
+
+            let errors =
+                diagnostics
+                |> List.filter(fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+                |> List.map Gen.formatDiagnostic
+
+            if List.isEmpty errors then
+                source
+            else
+                String.concat System.Environment.NewLine errors
+        with ex ->
+            ex.Message
+
+    /// <summary>
+    /// Renders <paramref name="widget"/> to source and parses it back to confirm
+    /// Fabulous.AST produced syntactically valid F#. Returns the rendered source
+    /// when valid, otherwise the formatted error diagnostics (or the render
+    /// failure message) separated by the OS newline.
+    /// </summary>
+    static member parse(widget: WidgetBuilder<Oak>) : string =
+        try
+            Gen.mkOak widget |> Gen.run |> Gen.parse
+        with ex ->
+            ex.Message
 
 module String =
     // Taken from https://github.com/dotnet/fsharp/blob/8e773e70700eea38f472950fd042ac0065dabae0/src/FSharp.Build/WriteCodeFragment.fs#L26-L44

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
@@ -10,8 +10,7 @@ module AbstractSlot =
     let ReturnType = Attributes.defineWidget "ReturnType"
     let Parameters = Attributes.defineScalar<MethodParamsType> "Parameters"
 
-    let HasGetterSetter =
-        Attributes.defineScalar<(bool * AccessControl) * (bool * AccessControl)> "HasGetterSetter"
+    let HasGetterSetter = Attributes.defineScalar<bool * bool> "HasGetterSetter"
 
     let WidgetKey =
         Widgets.register "AbstractMember" (fun widget ->
@@ -66,7 +65,10 @@ module AbstractSlot =
                 | [] -> returnType
                 | parameters -> Type.Funs(TypeFunsNode(parameters, returnType, Range.Zero))
 
-            let withGetSetText = MultipleTextsNode.CreateGetSet(hasGetter, hasSetter)
+            // Abstract slots always have the visibility of the enclosing type;
+            // F# forbids accessibility modifiers on their accessors, so drop them.
+            let withGetSetText =
+                MultipleTextsNode.CreateGetSet((hasGetter, AccessControl.Unknown), (hasSetter, AccessControl.Unknown))
 
             let isStatic =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
@@ -106,8 +108,6 @@ module AbstractMemberBuilders =
         /// <param name="returnType">The return type of the member.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -118,28 +118,17 @@ module AbstractMemberBuilders =
         /// }
         /// </code>
         static member AbstractMember
-            (
-                identifier: string,
-                returnType: WidgetBuilder<Type>,
-                ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
-            ) =
+            (identifier: string, returnType: WidgetBuilder<Type>, ?hasGetter: bool, ?hasSetter: bool)
+            =
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             WidgetBuilder<MemberDefn>(
                 AbstractSlot.WidgetKey,
                 AttributesBundle(
                     StackList.two(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        )
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter)
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
                     Array.empty
@@ -151,8 +140,6 @@ module AbstractMemberBuilders =
         /// <param name="returnType">The return type of the member.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -162,28 +149,11 @@ module AbstractMemberBuilders =
         ///     }
         /// }
         /// </code>
-        static member AbstractMember
-            (
-                identifier: string,
-                returnType: string,
-                ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
-            ) =
+        static member AbstractMember(identifier: string, returnType: string, ?hasGetter: bool, ?hasSetter: bool) =
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
-            Ast.AbstractMember(
-                identifier,
-                Ast.LongIdent(returnType),
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, Ast.LongIdent(returnType), hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -192,8 +162,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -210,25 +178,18 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             WidgetBuilder<MemberDefn>(
                 AbstractSlot.WidgetKey,
                 AttributesBundle(
                     StackList.three(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        ),
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter),
                         AbstractSlot.Parameters.WithValue(UnNamed(parameters, isTupled))
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
@@ -243,8 +204,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -261,27 +220,14 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map Ast.LongIdent
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -290,8 +236,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -308,27 +252,14 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -337,8 +268,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -355,28 +284,15 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map Ast.LongIdent
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -385,8 +301,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -403,15 +317,11 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             let parameters = List.ofSeq parameters
 
@@ -424,10 +334,7 @@ module AbstractMemberBuilders =
                 AttributesBundle(
                     StackList.three(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        ),
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter),
                         AbstractSlot.Parameters.WithValue(Named(parameters, isTupled))
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
@@ -442,8 +349,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -460,27 +365,14 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map(fun (name, tp) -> name, Ast.LongIdent(tp))
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -489,8 +381,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -507,27 +397,14 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -536,8 +413,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -554,25 +429,12 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map(fun (name, tp) -> name, Ast.LongIdent(tp))
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
@@ -20,6 +20,37 @@ module Record =
 
             let fields = Widgets.getNodesFromWidgetCollection<FieldNode> widget RecordCaseNode
 
+            // Accessibility modifiers are not permitted on individual record fields;
+            // F# only allows accessibility on the whole representation. Lift any
+            // field-level accessibility onto the record (most restrictive wins) and
+            // strip it from the fields.
+            let fieldAccessibility =
+                fields
+                |> List.choose(fun field -> field.Accessibility)
+                |> List.sortBy(fun node ->
+                    match node.Text with
+                    | "private" -> 0
+                    | "internal" -> 1
+                    | _ -> 2)
+                |> List.tryHead
+
+            let fields =
+                fields
+                |> List.map(fun field ->
+                    match field.Accessibility with
+                    | None -> field
+                    | Some _ ->
+                        FieldNode(
+                            field.XmlDoc,
+                            field.Attributes,
+                            field.LeadingKeyword,
+                            field.MutableKeyword,
+                            None,
+                            field.Name,
+                            field.Type,
+                            Range.Zero
+                        ))
+
             let members =
                 Widgets.tryGetNodesFromWidgetCollection widget TypeDefn.Members
                 |> ValueOption.defaultValue []
@@ -53,7 +84,7 @@ module Record =
                 | Public -> Some(SingleTextNode.``public``)
                 | Private -> Some(SingleTextNode.``private``)
                 | Internal -> Some(SingleTextNode.``internal``)
-                | Unknown -> None
+                | Unknown -> fieldAccessibility
 
             TypeDefn.Record(
                 TypeDefnRecordNode(


### PR DESCRIPTION
## Summary

Adds `Verify.parses` — round-trip syntactic verification of generated F# source.

```fsharp
let widget =
    Oak() {
        AnonymousModule() {
            Value(\"greet\", \"x + 1\")
        }
    }

match Verify.parses widget with
| Ok oak -> // generated source parsed cleanly
| Error diagnostics -> // Fantomas couldn't parse what we emitted
```

Two entry points:

| Method | Input | Output |
|---|---|---|
| `Verify.parses(widget)` | `WidgetBuilder<Oak>` | `Result<Oak, string list>` |
| `Verify.parses(source)` | `string` | `Result<Oak, string list>` |

## Why

Today, if the widget DSL produces an Oak that round-trips to syntactically broken source, the failure surfaces wherever the source is consumed (often \`dotnet build\` against the written files in CI). \`Verify.parses\` lets a codegen test catch the problem at generation time with a clear F# error.

## Scope — what this catches

- Output that the F# parser can't read at all.
- Output where Fantomas rejects the result of its own formatter (an internal consistency check).

## Scope — what this does NOT catch

- Type errors (undefined identifier, wrong arg type, missing reference).
- Runtime errors.
- Semantic equivalence to what the user intended.

For type-checking, the honest path is to run the real compiler against the written files. A future \`Fabulous.AST.Verify\` companion package could wrap FCS for in-process type checking, but that's an opt-in dependency and not part of this PR.

## Tests

3 new tests in \`src/Fabulous.AST.Tests/Verify/ParsesTests.fs\`:
- Widget round-trips cleanly.
- Valid source string parses.
- Invalid source returns Error with diagnostics.

Full suite: 812 / 812 passing.

## Test plan

- [x] All 3 new tests pass
- [x] Existing 809 tests still pass
- [x] \`dotnet fantomas --check\` passes
- [x] Builds clean on net8.0, net10.0, netstandard2.1