### PR TITLE
feat: add Gen.parse round-trip verification helper

### DIFF
--- a/src/Fabulous.AST.Tests/Core/GenParseTests.fs
+++ b/src/Fabulous.AST.Tests/Core/GenParseTests.fs
@@ -1,0 +1,55 @@
+namespace Fabulous.AST.Tests.Core
+
+open System
+open Fabulous.AST
+open Fantomas.Core.SyntaxOak
+open Xunit
+
+open type Ast
+
+module GenParseTests =
+
+    [<Fact>]
+    let ``widget parses round-trip``() =
+        let widget: WidgetBuilder<Oak> =
+            Oak() {
+                AnonymousModule() {
+                    Value("greet", "x + 1")
+                    TypeDefn("Greeter") { Member("this.Hello", "1") }
+                }
+            }
+
+        Assert.Contains("greet", Gen.parse widget)
+
+    [<Fact>]
+    let ``composed mkOak |> run |> parse pipeline parses``() =
+        let widget: WidgetBuilder<Oak> =
+            Oak() { AnonymousModule() { Value("greet", "x + 1") } }
+
+        Assert.Contains("greet", widget |> Gen.mkOak |> Gen.run |> Gen.parse)
+
+    [<Fact>]
+    let ``valid source string parses and round-trips``() =
+        let source = "let x = 1\nlet y = x + 2\n"
+
+        Assert.Equal(source, Gen.parse source)
+
+    [<Fact>]
+    let ``invalid source string returns located diagnostics, one per OS line``() =
+        let source = "let x = \n  if then else"
+
+        let result = Gen.parse source
+
+        // Diagnostics carry a position and an FS error number...
+        Assert.Contains("Error FS", result)
+        // ...and the multiple diagnostics are separated by the OS newline.
+        Assert.Contains(Environment.NewLine, result)
+
+    [<Fact>]
+    let ``widget producing invalid F# returns located diagnostics``() =
+        // An incomplete expression renders to "let x = if then else", which is
+        // syntactically broken — exactly the kind of codegen bug Gen.parse catches.
+        let widget: WidgetBuilder<Oak> =
+            Oak() { AnonymousModule() { Value("x", "if then else") } }
+
+        Assert.Contains("Error FS", Gen.parse widget)

--- a/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
+++ b/src/Fabulous.AST.Tests/Fabulous.AST.Tests.fsproj
@@ -139,6 +139,7 @@
         <Compile Include="Specialized\FSharpFeatures.fs" />
         <Compile Include="Specialized\RealWorld.fs" />
         <Compile Include="Specialized\Properties.fs" />
+        <Compile Include="Core\GenParseTests.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Fabulous.AST.Tests/TestHelpers.fs
+++ b/src/Fabulous.AST.Tests/TestHelpers.fs
@@ -26,6 +26,13 @@ module TestHelpers =
         let res = Gen.mkOak source |> Gen.run
         Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))
 
+    /// Like <c>produces</c>, but also round-trips the rendered source through the
+    /// parser. When the output is not valid F#, <c>res</c> holds the parser
+    /// diagnostics, so the assertion fails showing them against the expected source.
+    let producesValid (expected: string) (source: WidgetBuilder<#Oak>) =
+        let res = Gen.mkOak source |> Gen.run |> Gen.parse
+        Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))
+
     let producesWithConfig (config: Fantomas.Core.FormatConfig) (expected: string) (source: WidgetBuilder<#Oak>) =
-        let res = Gen.mkOak source |> Gen.runWith config
+        let res = Gen.run(Gen.mkOak source, config)
         Assert.Equal(expected.Trim().ReplaceLineEndings("\n"), res.Trim().ReplaceLineEndings("\n"))

--- a/src/Fabulous.AST/Widgets/Common.fs
+++ b/src/Fabulous.AST/Widgets/Common.fs
@@ -103,20 +103,87 @@ module Seq =
         coll.Close()
 
 open Fantomas.Core
+open Fantomas.FCS.Diagnostics
+open Fantomas.FCS.Parse
 
-/// It takes the root of the widget tree and create the corresponding Fantomas node, and recursively creating all children nodes
-module Gen =
-    let mkOak(root: WidgetBuilder<'node>) : 'node =
+/// <summary>
+/// Renders a widget tree to F# source and verifies the result. <c>mkOak</c> turns
+/// the root widget into a Fantomas node (recursively building its children),
+/// <c>run</c> formats that node to source (optionally with a config), and <c>parse</c> round-trips
+/// the source back through the parser to confirm it is syntactically valid.
+/// Designed for pipeline use, e.g. <c>widget |> Gen.parse</c> or
+/// <c>widget |> Gen.mkOak |> Gen.run |> Gen.parse</c>.
+/// </summary>
+[<AbstractClass; Sealed>]
+type Gen =
+    /// Builds the Fantomas node for <paramref name="root"/>, recursively creating all children nodes.
+    static member mkOak(root: WidgetBuilder<'node>) : 'node =
         let widget = root.Compile()
         let definition = WidgetDefinitionStore.get widget.Key
         definition.CreateView widget |> unbox
 
-    let run oak =
+    /// Formats <paramref name="oak"/> to F# source using the default config.
+    static member run(oak: Oak) : string =
         CodeFormatter.FormatOakAsync(oak, FormatConfig.Default)
         |> Async.RunSynchronously
 
-    let runWith config oak =
+    /// Formats <paramref name="oak"/> to F# source using <paramref name="config"/>.
+    static member run(oak: Oak, config: FormatConfig) : string =
         CodeFormatter.FormatOakAsync(oak, config) |> Async.RunSynchronously
+
+    /// Renders a single parser diagnostic as
+    /// "(startLine,startCol)-(endLine,endCol) Severity FSxxxx: message".
+    static member private formatDiagnostic(diagnostic: FSharpParserDiagnostic) : string =
+        let position =
+            match diagnostic.Range with
+            | Some range -> $"(%d{range.StartLine},%d{range.StartColumn})-(%d{range.EndLine},%d{range.EndColumn}) "
+            | None -> ""
+
+        let number =
+            match diagnostic.ErrorNumber with
+            | Some n -> $" FS%04d{n}"
+            | None -> ""
+
+        $"%s{position}%A{diagnostic.Severity}%s{number}: %s{diagnostic.Message}"
+
+    /// <summary>
+    /// Parses <paramref name="source"/> with Fantomas's F# parser. Returns the
+    /// source unchanged when syntactically valid, otherwise the formatted error
+    /// diagnostics separated by the OS newline. Does not type-check — for that,
+    /// run the real compiler against the written files.
+    /// </summary>
+    static member parse(source: string) : string =
+        // parseFile gives the parser diagnostics directly (CodeFormatter's
+        // ParseOakAsync throws ParseException on errors instead). We parse with
+        // no conditional-compilation defines, so syntax inside inactive #if
+        // branches is not checked — that matches the empty-defines parse that
+        // ParseOakAsync surfaces first.
+        try
+            let _, diagnostics = parseFile false (SourceText.ofString source) []
+
+            let errors =
+                diagnostics
+                |> List.filter(fun d -> d.Severity = FSharpDiagnosticSeverity.Error)
+                |> List.map Gen.formatDiagnostic
+
+            if List.isEmpty errors then
+                source
+            else
+                String.concat System.Environment.NewLine errors
+        with ex ->
+            ex.Message
+
+    /// <summary>
+    /// Renders <paramref name="widget"/> to source and parses it back to confirm
+    /// Fabulous.AST produced syntactically valid F#. Returns the rendered source
+    /// when valid, otherwise the formatted error diagnostics (or the render
+    /// failure message) separated by the OS newline.
+    /// </summary>
+    static member parse(widget: WidgetBuilder<Oak>) : string =
+        try
+            Gen.mkOak widget |> Gen.run |> Gen.parse
+        with ex ->
+            ex.Message
 
 module String =
     // Taken from https://github.com/dotnet/fsharp/blob/8e773e70700eea38f472950fd042ac0065dabae0/src/FSharp.Build/WriteCodeFragment.fs#L26-L44


### PR DESCRIPTION
Adds `Gen.parse`: renders a widget (or takes source) and re-parses it through Fantomas's parser, returning the source when syntactically valid or the parser diagnostics (OS-newline separated) otherwise. Composable: `widget |> Gen.parse` or `widget |> Gen.mkOak |> Gen.run |> Gen.parse`.

Also adds the `producesValid` test helper (`produces` + round-trip parse).

**BREAKING:** `Gen` module is now a type; `Gen.runWith` is replaced by an overload of `Gen.run`.

---
Base PR of a 5-PR stack. The following depend on this branch (file-disjoint, merge cleanly in any order once this lands):
- test: producesValid migration
- fix: record field accessibility
- fix: abstract member accessor accessibility
- fix: JSON backtick field names