### PR TITLE
fix: lift record field accessibility to the representation

### DIFF
--- a/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
@@ -18,7 +18,7 @@ module Record =
     [<InlineData("2013", "``2013``")>]
     let ``Produces a record with fields with backticks`` (value: string) (expected: string) =
         Oak() { AnonymousModule() { Record("Person") { Field(value, LongIdent("int")) } } }
-        |> produces
+        |> producesValid
             $$"""
 
 type Person = { {{expected}}: int }
@@ -36,7 +36,7 @@ type Person = { {{expected}}: int }
                     .attribute(Attribute "Serializable")
             }
         }
-        |> produces
+        |> producesValid
             """
 
 [<Serializable>]
@@ -56,7 +56,7 @@ type Colors = { Red: int; Green: int; Blue: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Colors =
@@ -80,7 +80,7 @@ type Colors =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 
 type Colors<'other> =
@@ -104,7 +104,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 [<Struct>]
 type Colors<'other> =
@@ -129,7 +129,7 @@ type Colors<'other> =
             }
         }
 
-        |> produces
+        |> producesValid
             """
 [<Struct; Obsolete>]
 type Colors<'other> =
@@ -157,7 +157,7 @@ type Colors<'other> =
                 |> _.toRecursive()
             }
         }
-        |> produces
+        |> producesValid
             """
 type Person =
     { Name: string
@@ -185,7 +185,7 @@ and Address =
 
         [ "G"; "B" ]
         |> generateModel
-        |> produces
+        |> producesValid
             """
 type R = { X: float }
 type G = { X: float }
@@ -197,7 +197,7 @@ type B = { X: float }
         Oak() {
             AnonymousModule() { Record("Color") { yield! [ Field("R", Int()); Field("G", Int()); Field("B", Int()) ] } }
         }
-        |> produces
+        |> producesValid
             """
 type Color = { R: int; G: int; B: int }
 """
@@ -212,9 +212,9 @@ type Color = { R: int; G: int; B: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { private Name: string; Age: int }
+type Person = private { Name: string; Age: int }
 """
 
     [<Fact>]
@@ -227,9 +227,9 @@ type Person = { private Name: string; Age: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { internal Name: string; Age: int }
+type Person = internal { Name: string; Age: int }
 """
 
     [<Fact>]
@@ -242,7 +242,7 @@ type Person = { internal Name: string; Age: int }
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
-type Person = { public Name: string; Age: int }
+type Person = public { Name: string; Age: int }
 """

--- a/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST.Tests/TypeDefinitions/Record.fs
@@ -246,3 +246,18 @@ type Person = internal { Name: string; Age: int }
             """
 type Person = public { Name: string; Age: int }
 """
+
+    [<Fact>]
+    let ``Produces a record with mixed field accessibility (most restrictive wins)``() =
+        Oak() {
+            AnonymousModule() {
+                Record("Person") {
+                    Field("Name", String()).toInternal()
+                    Field("Age", Int()).toPrivate()
+                }
+            }
+        }
+        |> producesValid
+            """
+type Person = private { Name: string; Age: int }
+"""

--- a/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
+++ b/src/Fabulous.AST/Widgets/TypeDefinitions/Record.fs
@@ -20,6 +20,37 @@ module Record =
 
             let fields = Widgets.getNodesFromWidgetCollection<FieldNode> widget RecordCaseNode
 
+            // Accessibility modifiers are not permitted on individual record fields;
+            // F# only allows accessibility on the whole representation. Lift any
+            // field-level accessibility onto the record (most restrictive wins) and
+            // strip it from the fields.
+            let fieldAccessibility =
+                fields
+                |> List.choose(fun field -> field.Accessibility)
+                |> List.sortBy(fun node ->
+                    match node.Text with
+                    | "private" -> 0
+                    | "internal" -> 1
+                    | _ -> 2)
+                |> List.tryHead
+
+            let fields =
+                fields
+                |> List.map(fun field ->
+                    match field.Accessibility with
+                    | None -> field
+                    | Some _ ->
+                        FieldNode(
+                            field.XmlDoc,
+                            field.Attributes,
+                            field.LeadingKeyword,
+                            field.MutableKeyword,
+                            None,
+                            field.Name,
+                            field.Type,
+                            Range.Zero
+                        ))
+
             let members =
                 Widgets.tryGetNodesFromWidgetCollection widget TypeDefn.Members
                 |> ValueOption.defaultValue []
@@ -53,7 +84,7 @@ module Record =
                 | Public -> Some(SingleTextNode.``public``)
                 | Private -> Some(SingleTextNode.``private``)
                 | Internal -> Some(SingleTextNode.``internal``)
-                | Unknown -> None
+                | Unknown -> fieldAccessibility
 
             TypeDefn.Record(
                 TypeDefnRecordNode(


### PR DESCRIPTION
Field accessibility is not permitted on individual record fields; F# only allows it on the whole representation. `Field(...).toPrivate()` now produces `type R = private { ... }` instead of the illegal `{ private Name: ... }`; most restrictive wins across fields.

Stacked on #191.