### PR TITLE
fix: drop accessibility modifiers on abstract member accessors

### DIFF
--- a/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST.Tests/MemberDefinitions/AbstractSlot.fs
@@ -43,7 +43,7 @@ module AbstractMembers =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     abstract Area: float with get
@@ -78,7 +78,7 @@ type Meh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     [<Obsolete>]
@@ -123,7 +123,7 @@ type Meh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh =
     abstract Area: float with get
@@ -181,7 +181,7 @@ type Meh =
                 |> _.typeParams(PostfixList([ "'other"; "'another" ]))
             }
         }
-        |> produces
+        |> producesValid
             """
 type Meh<'other, 'another> =
     abstract Area: float with get
@@ -233,7 +233,7 @@ type Meh<'other, 'another> =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     inherit IFoo
@@ -273,7 +273,7 @@ type IMeh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     abstract ClientInfo1:
@@ -313,7 +313,7 @@ type IMeh =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type IMeh =
     abstract ClientInfo1:
@@ -326,357 +326,31 @@ type IMeh =
 """
 
     [<Fact>]
-    let ``Abstract member with public get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Private) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member with plain get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, setterAccessibility = AccessControl.Private) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member with internal get, plain set``() =
-        Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal) } } }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Internal) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member with internal get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal, AccessControl.Internal) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public, AccessControl.Public) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member with plain get, plain set``() =
+    let ``Abstract member with get, set``() =
         Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true) } } }
-        |> produces
+        |> producesValid
             """
 type X =
     abstract Y: int with get, set
 """
 
     [<Fact>]
-    let ``Abstract member with internal get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Internal, AccessControl.Public) }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Y: int with internal get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member with public get, plain set``() =
-        Oak() { AnonymousModule() { TypeDefn("X") { AbstractMember("Y", Int(), true, true, AccessControl.Public) } } }
-        |> produces
-            """
-type X =
-    abstract Y: int with public get, set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, private set``() =
+    let ``Abstract member parameters with get, set``() =
         Oak() {
             AnonymousModule() {
                 TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Private
-                    )
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), false, true, true)
 
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Private
-                    )
+                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true, true, true)
 
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
-    abstract Add: a: int -> b: int -> int with internal get, private set
-    abstract Add: a: int * b: int -> int with internal get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, private set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Private
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Private
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, private set
-    abstract Add: a: int * b: int -> int with public get, private set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Public
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, public set
-    abstract Add: a: int * b: int -> int with public get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Internal
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Internal
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with internal get, internal set
-    abstract Add: a: int * b: int -> int with internal get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, internal set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Internal
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Public,
-                        AccessControl.Internal
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, internal set
-    abstract Add: a: int * b: int -> int with public get, internal set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with internal get, public set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        true,
-                        true,
-                        true,
-                        AccessControl.Internal,
-                        AccessControl.Public
-                    )
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with internal get, public set
-    abstract Add: a: int * b: int -> int with internal get, public set
-"""
-
-    [<Fact>]
-    let ``Abstract member parameters with public get, plain set``() =
-        Oak() {
-            AnonymousModule() {
-                TypeDefn("X") {
-                    AbstractMember(
-                        "Add",
-                        [ ("a", Int()); ("b", Int()) ],
-                        Int(),
-                        false,
-                        true,
-                        true,
-                        AccessControl.Public
-                    )
-
-                    AbstractMember("Add", [ ("a", Int()); ("b", Int()) ], Int(), true, true, true, AccessControl.Public)
-
-                }
-            }
-        }
-        |> produces
-            """
-type X =
-    abstract Add: a: int -> b: int -> int with public get, set
-    abstract Add: a: int * b: int -> int with public get, set
+    abstract Add: a: int -> b: int -> int with get, set
+    abstract Add: a: int * b: int -> int with get, set
 """
 
     [<Fact>]
@@ -691,7 +365,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     static abstract Add: a: int -> b: int -> int
@@ -712,7 +386,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     /// <summary>
@@ -735,7 +409,7 @@ type X =
                 }
             }
         }
-        |> produces
+        |> producesValid
             """
 type X =
     static abstract Area: float with get

--- a/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
+++ b/src/Fabulous.AST/Widgets/MemberDefinitions/AbstractSlot.fs
@@ -10,8 +10,7 @@ module AbstractSlot =
     let ReturnType = Attributes.defineWidget "ReturnType"
     let Parameters = Attributes.defineScalar<MethodParamsType> "Parameters"
 
-    let HasGetterSetter =
-        Attributes.defineScalar<(bool * AccessControl) * (bool * AccessControl)> "HasGetterSetter"
+    let HasGetterSetter = Attributes.defineScalar<bool * bool> "HasGetterSetter"
 
     let WidgetKey =
         Widgets.register "AbstractMember" (fun widget ->
@@ -66,7 +65,10 @@ module AbstractSlot =
                 | [] -> returnType
                 | parameters -> Type.Funs(TypeFunsNode(parameters, returnType, Range.Zero))
 
-            let withGetSetText = MultipleTextsNode.CreateGetSet(hasGetter, hasSetter)
+            // Abstract slots always have the visibility of the enclosing type;
+            // F# forbids accessibility modifiers on their accessors, so drop them.
+            let withGetSetText =
+                MultipleTextsNode.CreateGetSet((hasGetter, AccessControl.Unknown), (hasSetter, AccessControl.Unknown))
 
             let isStatic =
                 Widgets.tryGetScalarValue widget BindingNode.IsStatic
@@ -106,8 +108,6 @@ module AbstractMemberBuilders =
         /// <param name="returnType">The return type of the member.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -118,28 +118,17 @@ module AbstractMemberBuilders =
         /// }
         /// </code>
         static member AbstractMember
-            (
-                identifier: string,
-                returnType: WidgetBuilder<Type>,
-                ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
-            ) =
+            (identifier: string, returnType: WidgetBuilder<Type>, ?hasGetter: bool, ?hasSetter: bool)
+            =
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             WidgetBuilder<MemberDefn>(
                 AbstractSlot.WidgetKey,
                 AttributesBundle(
                     StackList.two(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        )
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter)
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
                     Array.empty
@@ -151,8 +140,6 @@ module AbstractMemberBuilders =
         /// <param name="returnType">The return type of the member.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -162,28 +149,11 @@ module AbstractMemberBuilders =
         ///     }
         /// }
         /// </code>
-        static member AbstractMember
-            (
-                identifier: string,
-                returnType: string,
-                ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
-            ) =
+        static member AbstractMember(identifier: string, returnType: string, ?hasGetter: bool, ?hasSetter: bool) =
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
-            Ast.AbstractMember(
-                identifier,
-                Ast.LongIdent(returnType),
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, Ast.LongIdent(returnType), hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -192,8 +162,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -210,25 +178,18 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             WidgetBuilder<MemberDefn>(
                 AbstractSlot.WidgetKey,
                 AttributesBundle(
                     StackList.three(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        ),
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter),
                         AbstractSlot.Parameters.WithValue(UnNamed(parameters, isTupled))
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
@@ -243,8 +204,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -261,27 +220,14 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map Ast.LongIdent
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -290,8 +236,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -308,27 +252,14 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -337,8 +268,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -355,28 +284,15 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map Ast.LongIdent
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -385,8 +301,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -403,15 +317,11 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
 
             let parameters = List.ofSeq parameters
 
@@ -424,10 +334,7 @@ module AbstractMemberBuilders =
                 AttributesBundle(
                     StackList.three(
                         AbstractSlot.Identifier.WithValue(identifier),
-                        AbstractSlot.HasGetterSetter.WithValue(
-                            (hasGetter, getterAccessibility),
-                            (hasSetter, setterAccessibility)
-                        ),
+                        AbstractSlot.HasGetterSetter.WithValue(hasGetter, hasSetter),
                         AbstractSlot.Parameters.WithValue(Named(parameters, isTupled))
                     ),
                     [| AbstractSlot.ReturnType.WithValue(returnType.Compile()) |],
@@ -442,8 +349,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -460,27 +365,14 @@ module AbstractMemberBuilders =
                 returnType: WidgetBuilder<Type>,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map(fun (name, tp) -> name, Ast.LongIdent(tp))
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -489,8 +381,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -507,27 +397,14 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)
 
         /// <summary>Creates an abstract member with parameters.</summary>
         /// <param name="identifier">The identifier of the member.</param>
@@ -536,8 +413,6 @@ module AbstractMemberBuilders =
         /// <param name="isTupled">Whether the parameters are tupled.</param>
         /// <param name="hasGetter">Whether the member has a getter.</param>
         /// <param name="hasSetter">Whether the member has a setter.</param>
-        /// <param name="getterAccessibility">The accessibility of the getter.</param>
-        /// <param name="setterAccessibility">The accessibility of the setter.</param>
         /// <code language="fsharp">
         /// Oak() {
         ///     AnonymousModule() {
@@ -554,25 +429,12 @@ module AbstractMemberBuilders =
                 returnType: string,
                 ?isTupled: bool,
                 ?hasGetter: bool,
-                ?hasSetter: bool,
-                ?getterAccessibility: AccessControl,
-                ?setterAccessibility: AccessControl
+                ?hasSetter: bool
             ) =
             let isTupled = defaultArg isTupled false
             let hasGetter = defaultArg hasGetter false
             let hasSetter = defaultArg hasSetter false
-            let getterAccessibility = defaultArg getterAccessibility AccessControl.Unknown
-            let setterAccessibility = defaultArg setterAccessibility AccessControl.Unknown
             let parameters = parameters |> Seq.map(fun (name, tp) -> name, Ast.LongIdent(tp))
             let returnType = Ast.LongIdent(returnType)
 
-            Ast.AbstractMember(
-                identifier,
-                parameters,
-                returnType,
-                isTupled,
-                hasGetter,
-                hasSetter,
-                getterAccessibility,
-                setterAccessibility
-            )
+            Ast.AbstractMember(identifier, parameters, returnType, isTupled, hasGetter, hasSetter)


### PR DESCRIPTION
F# forbids accessibility modifiers on abstract slot accessors (they always have the enclosing type's visibility), so the codegen no longer emits them. Redundant accessibility-combo tests are consolidated.

**BREAKING:** `AbstractMember` no longer accepts `getterAccessibility`/`setterAccessibility`.

Stacked on #191.