### PR TITLE
fix: sanitize backticks in JSON-derived field names

### DIFF
--- a/extensions/Fabulous.AST.Json/Parsing.fs
+++ b/extensions/Fabulous.AST.Json/Parsing.fs
@@ -137,9 +137,10 @@ module Parsing =
         elif Char.IsDigit(name[0]) then
             "_" + name
         elif fsharpKeywords.Contains(name) || requiresBacktickEscaping name then
-            // Escape any existing backticks by doubling them
-            let escaped = name.Replace("``", "````")
-            "``" + escaped + "``"
+            // A double-backtick-quoted identifier cannot itself contain backticks,
+            // so replace any with underscores before quoting.
+            let safe = name.Replace("`", "_")
+            "``" + safe + "``"
         else
             name
 

--- a/src/Fabulous.AST.Tests/Extensions/Json.fs
+++ b/src/Fabulous.AST.Tests/Extensions/Json.fs
@@ -23,7 +23,7 @@ module JsonGeneration =
 
             AnonymousModule() { Json(json) }
         }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -34,7 +34,7 @@ type Root =
     [<Fact>]
     let ``Generates nested records``() =
         Oak() { AnonymousModule() { Json("{ \"user\": { \"name\": \"Alice\" } }") } }
-        |> produces
+        |> producesValid
             """
 
 type User = { name: string }
@@ -45,7 +45,7 @@ type Root = { user: User }
     [<Fact>]
     let ``Generates alias for root array and element record``() =
         Oak() { AnonymousModule() { Json("[ { \"id\": 1 } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { id: int }
@@ -56,7 +56,7 @@ type Root = RootItem list
     [<Fact>]
     let ``Generates alias for root string``() =
         Oak() { AnonymousModule() { Json("\"hello\"") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = string
@@ -72,7 +72,7 @@ type Root = string
                 )
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Address = { street: string; zip: string }
@@ -94,7 +94,7 @@ type Root =
     [<Fact>]
     let ``Marks fields optional across array of objects when missing or null``() =
         Oak() { AnonymousModule() { Json("[ { \"id\": 1, \"name\": \"Alice\" }, { \"id\": null } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { id: int option; name: string option }
@@ -118,7 +118,7 @@ type Root = RootItem list
                 Json(json).documentAllowTrailingCommas(true).documentCommentHandling(JsonCommentHandling.Skip)
             }
         }
-        |> produces
+        |> producesValid
             """
 
 type Root = { id: int; name: string }
@@ -128,7 +128,7 @@ type Root = { id: int; name: string }
     [<Fact>]
     let ``Parses array with trailing comma when enabled``() =
         Oak() { AnonymousModule() { Json("[1,2,]").documentAllowTrailingCommas(true) } }
-        |> produces
+        |> producesValid
             """
 
 type Root = int list
@@ -149,7 +149,7 @@ type Root = int list
 """
 
         Oak() { AnonymousModule() { Json(json).serializerOptions(ser) } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { id: int }
@@ -159,7 +159,7 @@ type Root = { id: int }
     [<Fact>]
     let ``Overrides root type name via modifier``() =
         Oak() { AnonymousModule() { Json("{ \"id\": 1 }").rootName("Person") } }
-        |> produces
+        |> producesValid
             """
 
 type Person = { id: int }
@@ -169,7 +169,7 @@ type Person = { id: int }
     [<Fact>]
     let ``Falls back to obj list for empty arrays``() =
         Oak() { AnonymousModule() { Json("{ \"items\": [] }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { items: obj list }
@@ -179,7 +179,7 @@ type Root = { items: obj list }
     [<Fact>]
     let ``Array of objects treats differently-cased keys as distinct by default and marks optional``() =
         Oak() { AnonymousModule() { Json("[ { \"ID\": 1 }, { \"id\": 2 } ]") } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { ID: int option; id: int option }
@@ -190,7 +190,7 @@ type Root = RootItem list
     [<Fact>]
     let ``Case-insensitive node option does not merge keys but makes both non-optional``() =
         Oak() { AnonymousModule() { Json("[ { \"ID\": 1 }, { \"id\": 2 } ]").nodePropertyNameCaseInsensitive(true) } }
-        |> produces
+        |> producesValid
             """
 
 type RootItem = { ID: int; id: int }
@@ -314,7 +314,7 @@ type Root = RootItem list
 """
 
         Oak() { AnonymousModule() { Json(json) } }
-        |> produces
+        |> producesValid
             """
 
 type TracingConfig = { Mode: string }
@@ -361,7 +361,7 @@ type Root = { Functions: FunctionsItem list }
     [<Fact>]
     let ``Handles field names starting with digits``() =
         Oak() { AnonymousModule() { Json("{ \"123field\": \"value\", \"1st\": 1 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { _123field: string; _1st: int }
@@ -371,7 +371,7 @@ type Root = { _123field: string; _1st: int }
     [<Fact>]
     let ``Handles large int64 numbers correctly``() =
         Oak() { AnonymousModule() { Json("{ \"bigNum\": 9223372036854775807 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { bigNum: int64 }
@@ -381,7 +381,7 @@ type Root = { bigNum: int64 }
     [<Fact>]
     let ``Handles floating point numbers``() =
         Oak() { AnonymousModule() { Json("{ \"price\": 123.456789012345 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { price: float }
@@ -391,7 +391,7 @@ type Root = { price: float }
     [<Fact>]
     let ``Handles null-only fields as obj option``() =
         Oak() { AnonymousModule() { Json("{ \"data\": null }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { data: obj }
@@ -401,7 +401,7 @@ type Root = { data: obj }
     [<Fact>]
     let ``Handles type name starting with digit in nested object``() =
         Oak() { AnonymousModule() { Json("{ \"123nested\": { \"value\": 1 } }") } }
-        |> produces
+        |> producesValid
             """
 
 type _123nested = { value: int }
@@ -412,7 +412,7 @@ type Root = { _123nested: _123nested }
     [<Fact>]
     let ``Escapes F# reserved keywords in field names``() =
         Oak() { AnonymousModule() { Json("{ \"type\": \"post\", \"module\": \"core\", \"match\": true }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -425,7 +425,7 @@ type Root =
     [<Fact>]
     let ``Handles field names with special characters``() =
         Oak() { AnonymousModule() { Json("{ \"field:name\": 1, \"field}name\": 2, \"field//comment\": 3 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -438,17 +438,17 @@ type Root =
     [<Fact>]
     let ``Handles field names with backticks``() =
         Oak() { AnonymousModule() { Json("{ \"field``name\": 1 }") } }
-        |> produces
+        |> producesValid
             """
 
-type Root = { ``field````name``: int }
+type Root = { ``field__name``: int }
 
 """
 
     [<Fact>]
     let ``Handles field names with spaces``() =
         Oak() { AnonymousModule() { Json("{ \"field name\": 1, \"another field\": 2 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root =
@@ -460,7 +460,7 @@ type Root =
     [<Fact>]
     let ``Normal field names are not wrapped in backticks``() =
         Oak() { AnonymousModule() { Json("{ \"normalName\": 1, \"another_field\": 2 }") } }
-        |> produces
+        |> producesValid
             """
 
 type Root = { normalName: int; another_field: int }


### PR DESCRIPTION
A double-backtick-quoted F# identifier cannot itself contain backticks, so JSON field names containing backticks now replace them with underscores instead of producing an invalid nested-backtick identifier.

Stacked on #191.