### PR TITLE
docs: document Gen.parse, Rewrite, and v2 breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes_
+### Added
+- `Gen.parse` round-trips a widget (or a source string) through Fantomas's F# parser and returns the rendered source when it is syntactically valid, or the parser diagnostics (one per line) otherwise — for catching widget combinations that produce invalid F# (#191)
+- `Rewrite.expr` / `Rewrite.exprInOak` and `Rewrite.typeDefn` / `Rewrite.typeDefnInOak`: curried, pipeline-friendly bottom-up rewriters that apply a transform to every expression (or type definition) reachable from an Oak — e.g. rename a call site everywhere, or convert a single-case union to a record (#189)
+- `producesValid` test helper: like `produces`, but also re-parses the rendered output to assert it is syntactically valid F# (#191, #192)
+
+### Changed
+- **Breaking:** `Gen` is now a sealed static type instead of a module so that `run` can be overloaded; `Gen.runWith config oak` is replaced by the `Gen.run(oak, config)` overload. `Gen.mkOak` and `Gen.run oak` are unchanged (#191)
+- **Breaking:** record field accessibility (`Field(...).toPrivate()` / `toInternal()` / `toPublic()`) now lifts to the whole record representation (`type R = private { ... }`) instead of emitting an invalid per-field modifier; the most restrictive accessibility wins when fields disagree (#193)
+
+### Fixed
+- Abstract member accessors no longer emit accessibility modifiers, which F# forbids on abstract slots (`abstract Y: int with get, set` rather than the invalid `with public get, public set`) (#194)
+- JSON field names containing backticks now replace them with underscores instead of producing an invalid nested-backtick identifier (#195)
+
+### Removed
+- **Breaking:** `getterAccessibility` / `setterAccessibility` parameters on `AbstractMember` — they rendered invalid F#, since abstract slots always have the enclosing type's visibility (#194)
 
 ## [2.0.0-pre07] - 2026-05-30
 

--- a/docs/migration-v2.fsx
+++ b/docs/migration-v2.fsx
@@ -459,6 +459,77 @@ Ast.Oak() {
 (*** include-output ***)
 
 (**
+## 6. `Gen` is now a type; `run` is overloaded
+
+`Gen` changed from a module to a sealed static class so that `run` can be
+overloaded. `Gen.mkOak` and `Gen.run oak` are unchanged; the old
+`Gen.runWith config oak` is replaced by the `Gen.run(oak, config)` overload.
+*)
+
+// Before (v1.x):
+// oak |> Gen.runWith config
+
+(**
+**After (v2.0):**
+*)
+
+open Fantomas.Core
+
+let configuredOak =
+    Ast.Oak() { AnonymousModule() { Value("x", Int 42) } } |> Gen.mkOak
+
+Gen.run(configuredOak, FormatConfig.Default) |> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## 7. `AbstractMember` accessibility parameters removed
+
+F# forbids accessibility modifiers on abstract slot accessors — they always have
+the enclosing type's visibility — so `AbstractMember` no longer accepts the
+`getterAccessibility` / `setterAccessibility` parameters.
+*)
+
+// Before:
+// AbstractMember("Area", Float(), true, true, AccessControl.Public, AccessControl.Private)
+
+(**
+**After (v2.0):**
+*)
+
+Ast.Oak() { AnonymousModule() { TypeDefn("IShape") { AbstractMember("Area", Float(), true, true) } } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## 8. Record field accessibility lifts to the representation
+
+Accessibility set on an individual record field (`Field(...).toPrivate()`) is no
+longer emitted per field — which is not valid F# — but applied to the whole
+record representation. When fields disagree, the most restrictive wins.
+*)
+
+Ast.Oak() {
+    AnonymousModule() {
+        Record("Person") {
+            Field("Name", String()).toPrivate()
+            Field("Age", Int())
+        }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
 ## Summary
 
 When migrating to v2.0.0:
@@ -467,6 +538,9 @@ When migrating to v2.0.0:
 2. **Wrap raw SyntaxOak nodes** with `EscapeHatch()` when yielding into collections
 3. **Use unified modifiers** like `toPrivate()`, `xmlDocs()`, `attribute()` which work consistently across all widget types
 4. **Update type annotations** if you explicitly typed variables with specific node types like `WidgetBuilder<BindingNode>` - change them to `WidgetBuilder<MemberDefn>`
+5. **Replace `Gen.runWith config oak`** with the `Gen.run(oak, config)` overload (`Gen` is now a type)
+6. **Drop `getterAccessibility` / `setterAccessibility`** arguments from `AbstractMember` calls
+7. **Move record accessibility to the type** if you relied on per-field modifiers — field accessibility now applies to the whole representation
 
 The v2.0 changes provide a cleaner, more consistent API while maintaining full compatibility with the Fantomas Oak AST.
 *)

--- a/docs/widgets/Oak.fsx
+++ b/docs/widgets/Oak.fsx
@@ -121,4 +121,26 @@ Oak() {
 (**
 Likewise, if you have other raw nodes (e.g., `TypeDefn.Abbrev`, `EnumCaseNode`, etc.), inject them via `EscapeHatch(...)`.
 The preferred approach remains to use the provided widgets (`Abbrev`, `EnumCase`, `Record`, `Value`, ...), which do not require `EscapeHatch`.
+
+## Verifying generated code
+
+`Gen.parse` round-trips the output through Fantomas's F# parser to confirm it is
+syntactically valid. It returns the rendered source when the code parses, or the
+parser diagnostics (one per line) otherwise — useful for catching widget
+combinations that produce broken output before a downstream consumer does. It is
+curried with the widget last, so it drops into the same pipeline as `Gen.run`:
+*)
+
+Oak() { AnonymousModule() { Value("greet", "x + 1") } }
+|> Gen.parse
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+`Gen.parse` does not type-check — run the real compiler against the written files
+for that. There is also an overload that takes a source `string` directly, and
+in test suites the `producesValid` helper builds on it to assert that every
+generated snippet parses.
 *)

--- a/docs/widgets/Records.fsx
+++ b/docs/widgets/Records.fsx
@@ -159,6 +159,27 @@ Oak() {
 (*** include-output ***)
 
 (**
+Accessibility can also be set on an individual field with `Field(...).toPrivate()`
+/ `toInternal()` / `toPublic()`. Because F# does not allow per-field accessibility,
+it is lifted to the whole record representation (the most restrictive wins):
+*)
+
+Oak() {
+    AnonymousModule() {
+        Record("Person") {
+            Field("Name", String()).toPrivate()
+            Field("Age", Int())
+        }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
 ## XML Documentation
 Add XML documentation to records with the `xmlDocs` method:
 *)

--- a/docs/widgets/Rewrite.fsx
+++ b/docs/widgets/Rewrite.fsx
@@ -1,0 +1,108 @@
+(**
+---
+title: Rewrite
+category: widgets
+index: 16
+---
+*)
+
+(**
+# Rewrite
+
+## Overview
+`Rewrite` applies a transformation to every node of a given kind reachable from a
+Fantomas Oak — through type definitions, member bodies, patterns, types and
+attributes. It is handy for cross-cutting passes that aren't tied to where you
+wrote the builder: rename every occurrence of a function call, convert a union to
+a record, strip XML docs, and so on.
+
+The functions are curried with the target last, so they drop into the usual
+pipeline. The `WidgetBuilder<Oak>` forms return the same builder when nothing
+changed (reference equality is preserved on unchanged subtrees).
+
+| Function | Signature |
+|---|---|
+| `Rewrite.expr` | `(Expr -> Expr) -> WidgetBuilder<Oak> -> WidgetBuilder<Oak>` |
+| `Rewrite.exprInOak` | `(Expr -> Expr) -> Oak -> Oak` |
+| `Rewrite.typeDefn` | `(TypeDefn -> TypeDefn) -> WidgetBuilder<Oak> -> WidgetBuilder<Oak>` |
+| `Rewrite.typeDefnInOak` | `(TypeDefn -> TypeDefn) -> Oak -> Oak` |
+*)
+
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+
+open Fabulous.AST
+open Fantomas.Core.SyntaxOak
+open Fantomas.FCS.Text
+open type Fabulous.AST.Ast
+
+(**
+## Rewriting expressions
+`Rewrite.expr` visits every `Expr` and applies your function after each node's
+children are rebuilt (bottom-up). Here we rename a function call. The widget DSL
+emits constants for raw identifier text (`ConstantExpr(Constant "x")` →
+`Expr.Constant`), so a real rewrite covers both `Expr.Ident` and `Expr.Constant`:
+*)
+
+let renameIdent (oldName: string) (newName: string) (e: Expr) : Expr =
+    match e with
+    | Expr.Ident n when n.Text = oldName -> Expr.Ident(SingleTextNode(newName, Range.Zero))
+    | Expr.Constant(Constant.FromText n) when n.Text = oldName ->
+        Expr.Constant(Constant.FromText(SingleTextNode(newName, Range.Zero)))
+    | _ -> e
+
+Oak() { AnonymousModule() { Value("greet", AppExpr(ConstantExpr(Constant "println"), [ Constant "msg" ])) } }
+|> Rewrite.expr(renameIdent "println" "printfn")
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Rewriting type definitions
+`Rewrite.typeDefn` visits each `TypeDefn`, so a pass can replace one shape with
+another. This converts a single-case union into the equivalent record by reusing
+the case's fields (a `UnionCaseNode`'s `Fields` are already `FieldNode`s):
+*)
+
+let unionToRecord(td: TypeDefn) : TypeDefn =
+    match td with
+    | TypeDefn.Union n when n.UnionCases.Length = 1 ->
+        let itd = n :> ITypeDefn
+
+        TypeDefn.Record(
+            TypeDefnRecordNode(
+                itd.TypeName,
+                n.Accessibility,
+                SingleTextNode("{", Range.Zero),
+                n.UnionCases.Head.Fields,
+                SingleTextNode("}", Range.Zero),
+                itd.Members,
+                Range.Zero
+            )
+        )
+    | _ -> td
+
+Oak() { AnonymousModule() { Union("Point") { UnionCase("Point", [ Field("X", Int()); Field("Y", Int()) ]) } } }
+|> Rewrite.typeDefn unionToRecord
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Working with raw Oak nodes
+When you already hold a raw `Oak` (rather than a `WidgetBuilder<Oak>`), use the
+`InOak` variants. They take the same transformation and return a rewritten `Oak`:
+
+```fsharp
+let oak = Gen.mkOak widget
+let renamed = oak |> Rewrite.exprInOak (renameIdent "println" "printfn")
+let asRecord = oak |> Rewrite.typeDefnInOak unionToRecord
+```
+*)


### PR DESCRIPTION
Documents the features and breaking changes merged via #189, #191–#195.

**New / updated pages**
- **`docs/widgets/Rewrite.fsx`** (new) — `Rewrite.expr` / `exprInOak` and `Rewrite.typeDefn` / `typeDefnInOak`, with rename-idents and single-case-union→record examples.
- **`Oak.fsx`** — a *Verifying generated code* section for `Gen.parse`.
- **`Records.fsx`** — note that field-level accessibility lifts to the whole record representation.
- **`migration-v2.fsx`** — new sections: `Gen` is now a type / `runWith`→`run(oak, config)`; `AbstractMember` accessibility params removed; record field accessibility; updated the summary.
- **`CHANGELOG.md`** — `[Unreleased]` entries (Added / Changed / Fixed / Removed).

**Verification**
- All examples compile and evaluate under `dotnet fsdocs build --eval --strict` (every example is verbatim from passing tests).
- `fantomas --check` clean on all changed `.fsx`.