### PR TITLE
docs: add pages for Enums, Exceptions, Delegates, Computation Expressions

### DIFF
--- a/docs/widgets/ComputationExpressions.fsx
+++ b/docs/widgets/ComputationExpressions.fsx
@@ -1,0 +1,77 @@
+(**
+---
+title: Computation Expressions
+category: widgets
+index: 20
+---
+*)
+
+(**
+# Computation Expressions
+
+## Contents
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Named Computation Expressions](#named-computation-expressions)
+- [Multi-statement Bodies](#multi-statement-bodies)
+*)
+
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+
+open Fabulous.AST
+open type Fabulous.AST.Ast
+
+(**
+## Overview
+A computation expression wraps a body in `{ ... }`. `ComputationExpr` produces an
+anonymous block; `NamedComputationExpr` prefixes it with a builder name such as
+`seq`, `async`, or `task`.
+
+## Basic Usage
+*)
+
+Oak() { AnonymousModule() { Value("block", ComputationExpr(ConstantExpr(String "a"))) } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Named Computation Expressions
+Pass the builder name to `NamedComputationExpr`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Value("greeting", NamedComputationExpr("async", ConstantExpr(String "hello")))
+
+        Value("work", NamedComputationExpr("task", ConstantExpr(String "done")))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Multi-statement Bodies
+Use `CompExprBodyExpr` to place several statements in the body:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Value("numbers", NamedComputationExpr("seq", CompExprBodyExpr([ "yield 1"; "yield 2"; "yield 3" ])))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)

--- a/docs/widgets/Delegates.fsx
+++ b/docs/widgets/Delegates.fsx
@@ -1,0 +1,76 @@
+(**
+---
+title: Delegates
+category: widgets
+index: 18
+---
+*)
+
+(**
+# Delegates
+
+## Contents
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Tupled and Named Parameters](#tupled-and-named-parameters)
+- [Access Modifiers](#access-modifiers)
+*)
+
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+
+open Fabulous.AST
+open type Fabulous.AST.Ast
+
+(**
+## Overview
+A delegate names a function signature. `Delegate` takes the type name, the
+parameter type(s), and the return type.
+
+## Basic Usage
+A single parameter and a return type:
+*)
+
+Oak() { AnonymousModule() { Delegate("IntTransform", Int(), Int()) } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Tupled and Named Parameters
+Pass a list of types (or type names) for several parameters, and use
+`SignatureParameter` to name them:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Delegate("BinaryOp", [ "int"; "int" ], "int")
+
+        Delegate("NamedArgs", Tuple([ SignatureParameter("a", Int()); SignatureParameter("b", Int()) ]), Int())
+
+        Delegate("Curried", [ Paren(Tuple([ Int(); Int() ])); Paren(Tuple([ Int(); Int() ])) ], Int())
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Access Modifiers
+Set accessibility with `toPrivate`, `toInternal`, or `toPublic`:
+*)
+
+Oak() { AnonymousModule() { Delegate("InternalOp", [ "int"; "int" ], "int") |> _.toInternal() } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)

--- a/docs/widgets/Enums.fsx
+++ b/docs/widgets/Enums.fsx
@@ -1,0 +1,93 @@
+(**
+---
+title: Enums
+category: widgets
+index: 17
+---
+*)
+
+(**
+# Enums
+
+## Contents
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Enum Cases](#enum-cases)
+- [Attributes and XML Documentation](#attributes-and-xml-documentation)
+*)
+
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+
+open Fabulous.AST
+open type Fabulous.AST.Ast
+
+(**
+## Overview
+An enumeration is a type with a fixed set of named integer constants. Build one
+with `Enum` and one `EnumCase` per value.
+
+## Basic Usage
+*)
+
+Oak() {
+    AnonymousModule() {
+        Enum("Color") {
+            EnumCase("Red", Int(0))
+            EnumCase("Green", Int(1))
+            EnumCase("Blue", Int(2))
+        }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Enum Cases
+Each case pairs a name with a constant value. The value can be a constant widget
+(`Int`, `Char`, ...) or a full `ConstantExpr`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Enum("FileAccess") {
+            EnumCase("Read", Int(1))
+            EnumCase("Write", Int(2))
+            EnumCase("ReadWrite", ConstantExpr(Int 3))
+        }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Attributes and XML Documentation
+Add attributes and documentation with the unified modifiers:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Enum("Color") {
+            EnumCase("Red", Int(0))
+            EnumCase("Green", Int(1))
+            EnumCase("Blue", Int(2))
+        }
+        |> _.attribute(Attribute("Flags"))
+        |> _.xmlDocs([ "The primary colors" ])
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)

--- a/docs/widgets/Exceptions.fsx
+++ b/docs/widgets/Exceptions.fsx
@@ -1,0 +1,81 @@
+(**
+---
+title: Exceptions
+category: widgets
+index: 19
+---
+*)
+
+(**
+# Exceptions
+
+## Contents
+- [Overview](#overview)
+- [Basic Usage](#basic-usage)
+- [Exceptions with Fields](#exceptions-with-fields)
+- [Exception Members](#exception-members)
+*)
+
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fabulous.AST.dll"
+#r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.FCS.dll"
+
+open Fabulous.AST
+open type Fabulous.AST.Ast
+
+(**
+## Overview
+`ExceptionDefn` declares a custom exception type. In its simplest form it takes
+just a name.
+
+## Basic Usage
+*)
+
+Oak() { AnonymousModule() { ExceptionDefn("ParseError") } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Exceptions with Fields
+Carry data on the exception by passing a single `Field`, a list of fields, or a
+list of type names:
+*)
+
+Oak() {
+    AnonymousModule() {
+        ExceptionDefn("NotFound", Field("key", String()))
+
+        ExceptionDefn("ValidationError", [ Field("field", String()); Field("code", Int()) ])
+
+        ExceptionDefn("Failure", [ "string"; "int" ])
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Exception Members
+Add members with `.members()`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        ExceptionDefn("AppError", Field("message", String())).members() {
+            Member(ConstantPat(Constant("DefaultMessage")), ConstantExpr(String("unknown"))).toStatic()
+        }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)


### PR DESCRIPTION
Adds dedicated documentation pages for four DSL features that previously had no coverage:

- **Enums** — `Enum` / `EnumCase`, with attributes & XML docs
- **Exceptions** — `ExceptionDefn` with fields and members
- **Delegates** — `Delegate` with tupled/named parameters and accessibility
- **Computation Expressions** — `ComputationExpr` / `NamedComputationExpr` (seq/async/task) and multi-statement bodies via `CompExprBodyExpr`

All examples are verbatim from passing tests and evaluate under `dotnet fsdocs build --eval --strict`.

First of three doc batches filling DSL documentation gaps.