### PR TITLE
docs: restructure Expressions and Patterns into explained sections

### DIFF
--- a/docs/widgets/Expressions.fsx
+++ b/docs/widgets/Expressions.fsx
@@ -8,6 +8,19 @@ index: 7
 
 (**
 # Expressions
+
+Expressions are the building blocks of values, member bodies, and statements. The
+DSL exposes one widget per F# expression form — this page groups them by family.
+
+## Contents
+- [Identifiers and Literals](#identifiers-and-literals)
+- [Collections and Tuples](#collections-and-tuples)
+- [Application and Operators](#application-and-operators)
+- [Lambdas](#lambdas)
+- [Conditionals and Pattern Matching](#conditionals-and-pattern-matching)
+- [Loops](#loops)
+- [Exception Handling](#exception-handling)
+- [Other Expressions](#other-expressions)
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -17,111 +30,203 @@ index: 7
 open Fabulous.AST
 open type Fabulous.AST.Ast
 
+(**
+## Identifiers and Literals
+`IdentExpr` references an identifier and `InterpolatedStringExpr` builds an
+interpolated string (optionally verbatim, or with extra `$` for nested braces):
+*)
+
 Oak() {
     AnonymousModule() {
-        IdentExpr("1")
+        IdentExpr("value")
 
         InterpolatedStringExpr(ConstantExpr("12"))
 
-        InterpolatedStringExpr(ConstantExpr("12"), isVerbatim = true)
+        InterpolatedStringExpr([ "a"; "b"; "c" ], isVerbatim = true)
 
-        LazyExpr(Int(12))
+        InterpolatedStringExpr([ ConstantExpr("12"); ConstantExpr("12") ], isVerbatim = true, dollars = 1)
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Collections and Tuples
+Lists, arrays, sequences, tuples (and their struct variants), and anonymous
+records:
+*)
+
+Oak() {
+    AnonymousModule() {
         ListExpr([ String("a"); String("b"); String("c") ])
 
         ArrayExpr([ String("a"); String("b"); String("c") ])
 
         SeqExpr([ String("a"); String("b") ])
 
-        InfixAppExpr(Int(1), "+", Int(2))
-
-        StructTupleExpr([ ConstantExpr(Int 1); ConstantExpr(Int 2); ConstantExpr(Int 3) ])
-
         TupleExpr([ ConstantExpr(Int 1); ConstantExpr(Int 2); ConstantExpr(Int 3) ])
 
-        Open("System")
+        StructTupleExpr([ ConstantExpr(Int 1); ConstantExpr(Int 2) ])
+
+        AnonRecordExpr([ RecordFieldExpr("A", Int(1)); RecordFieldExpr("B", Int(2)) ])
+
+        AnonStructRecordExpr([ RecordFieldExpr("A", Int(1)); RecordFieldExpr("B", Int(2)) ])
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Application and Operators
+`AppExpr` applies a function, `InfixAppExpr` applies a binary operator, and
+`ChainExpr` builds a dotted call chain:
+*)
+
+Oak() {
+    AnonymousModule() {
+        AppExpr("printfn", String("Hello, World!"))
+
+        InfixAppExpr(Int(1), "+", Int(2))
 
         ChainExpr(
             [ ChainLinkExpr(String("string"))
               ChainLinkDot()
               ChainLinkExpr(OptVarExpr("Length")) ]
         )
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        AppExpr("printfn", String("Hello, World!"))
+// produces the following code:
+(*** include-output ***)
 
+(**
+## Lambdas
+`LambdaExpr` for a bare lambda, `ParenLambdaExpr` for a parenthesized one, and
+`MatchLambdaExpr` for the `function` form:
+*)
+
+Oak() {
+    AnonymousModule() {
         LambdaExpr(UnitPat(), Int(1))
 
-        ParenLambdaExpr(ConstantPat("a"), ConstantExpr("a"))
-
         ParenLambdaExpr([ ConstantPat("a"); ConstantPat("b") ], ConstantExpr("a"))
+
+        MatchLambdaExpr([ MatchClauseExpr("a", Int(3)) ])
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Conditionals and Pattern Matching
+`IfThenElseExpr`, the multi-branch `IfThenElifExpr`, and `MatchExpr` with a list
+of `MatchClauseExpr`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        IfThenElseExpr(Bool(true), String("a"), String("b"))
+
+        IfThenElifExpr(
+            [ IfThenExpr(
+                  InfixAppExpr(ConstantExpr(Constant "x"), "=", ConstantExpr(Int 1)),
+                  ConstantExpr(String("one"))
+              )
+              ElIfThenExpr(
+                  InfixAppExpr(ConstantExpr(Constant "x"), "=", ConstantExpr(Int 2)),
+                  ConstantExpr(String("two"))
+              ) ],
+            ConstantExpr(String("other"))
+        )
 
         MatchExpr(
             Int(1),
             [ MatchClauseExpr(Int(1), String("a"))
               MatchClauseExpr(WildPat(), String("b")) ]
         )
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        IfThenElseExpr(Bool(true), String("a"), String("b"))
+// produces the following code:
+(*** include-output ***)
 
-        IfThenElifExpr(
-            [ IfThenExpr(
-                  InfixAppExpr(ConstantExpr(Constant "1"), "=", ConstantExpr(Int 12)),
-                  ConstantExpr(ConstantUnit())
-              )
+(**
+## Loops
+`ForEachDoExpr`, the counted `ForToExpr` / `ForDownToExpr`, and `WhileExpr`:
+*)
 
-              ElIfThenExpr(
-                  InfixAppExpr(ConstantExpr(Constant("1")), "=", ConstantExpr(Int 11)),
-                  ConstantExpr(ConstantUnit())
-              ) ],
-            ConstantExpr(ConstantUnit())
-        )
-
+Oak() {
+    AnonymousModule() {
         ForEachDoExpr("i", ListExpr([ Int(1); Int(2); Int(3) ]), AppExpr("printf", String("%i")))
 
         ForToExpr("i", ConstantExpr("1"), ConstantExpr("10"), ConstantExpr(ConstantUnit()))
 
-        ForDownToExpr("i", ConstantExpr("1"), ConstantExpr("10"), ConstantExpr(ConstantUnit()))
+        ForDownToExpr("i", ConstantExpr("10"), ConstantExpr("1"), ConstantExpr(ConstantUnit()))
 
         WhileExpr(ConstantExpr(Bool(true)), ConstantExpr(Int(0)))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        TryWithExpr(
-            CompExprBodyExpr(
-                [ LetOrUseExpr(Value("result", InfixAppExpr(Int(1), "/", Int(0))))
-                  OtherExpr(AppExpr("printfn", [ String("%i"); Constant("result") ])) ]
-            ),
-            [ MatchClauseExpr("e", AppExpr("printfn", [ String("%s"); String("e.Message") ])) ]
-        )
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Exception Handling
+`TryWithExpr` (and the single-clause `TryWithSingleClauseExpr`) and `TryFinallyExpr`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        TryWithSingleClauseExpr(Int(12), MatchClauseExpr(WildPat(), FailWithExpr(String("Not implemented"))))
 
         TryFinallyExpr(Int(12), Int(12))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        TryWithSingleClauseExpr(Int(12), MatchClauseExpr(WildPat(), FailWithExpr(String("Not implemented"))))
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Other Expressions
+`LazyExpr`, `QuotedExpr`, the object expression `ObjExpr`, and named computation
+expressions such as `task { ... }`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        LazyExpr(Int(12))
 
         QuotedExpr(InfixAppExpr(Int(1), "+", Int(2)))
 
-        MatchLambdaExpr([ MatchClauseExpr("a", Int(3)) ])
-
         NamedComputationExpr(ConstantExpr(Constant "task"), String("a"))
-
-        NamedComputationExpr(Constant("task"), SingleExpr(SingleNode("return", String("a")).addSpace(true)))
-
-        AnonRecordExpr([ RecordFieldExpr("A", Int(1)); RecordFieldExpr("B", Int(2)) ])
-
-        AnonStructRecordExpr([ RecordFieldExpr("A", Int(1)); RecordFieldExpr("B", Int(2)) ])
 
         ObjExpr(LongIdent("System.Object"), ConstantExpr(ConstantUnit())) {
             Member("x.ToString()", ConstantExpr(String("F#")))
         }
-
-        AppExpr(ConstantExpr(Constant("printfn")), ConstantExpr(String("a")))
-
-        InterpolatedStringExpr([ "12"; "12"; "12" ], isVerbatim = true)
-
-        InterpolatedStringExpr(
-            [ ConstantExpr("12"); ConstantExpr("12"); ConstantExpr("12") ],
-            isVerbatim = true,
-            dollars = 1
-        )
-
     }
 }
 |> Gen.mkOak

--- a/docs/widgets/Patterns.fsx
+++ b/docs/widgets/Patterns.fsx
@@ -8,6 +8,17 @@ index: 8
 
 (**
 # Patterns
+
+Patterns appear on the left of bindings, in `match` clauses, and in function
+parameters. Each F# pattern form has a widget — this page groups them by kind.
+
+## Contents
+- [Named, Or, As, and Ands Patterns](#named-or-as-and-ands-patterns)
+- [Tuple Patterns](#tuple-patterns)
+- [List Patterns](#list-patterns)
+- [Record Patterns](#record-patterns)
+- [Type-test Patterns](#type-test-patterns)
+- [Parameter Patterns with Attributes](#parameter-patterns-with-attributes)
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -17,37 +28,19 @@ index: 8
 open Fabulous.AST
 open type Fabulous.AST.Ast
 
+(**
+## Named, Or, As, and Ands Patterns
+`OrPat` matches either alternative, `AsPat` binds the whole match to a name, and
+`AndsPat` requires all to match:
+*)
+
 Oak() {
     AnonymousModule() {
-        Union("Union") {
-            UnionCase("A")
-            UnionCase("B")
-            UnionCase("C")
-        }
-
-        Record("Record") { Field("A", Int()) }
-
         Value(OrPat(NamedPat("A"), "B"), ConstantExpr(Constant("C")))
 
         Value(AsPat(NamedPat("A"), "B"), ConstantExpr(Constant("C")))
 
         Value(AndsPat([ "A"; "B" ]), ConstantExpr(Constant("C")))
-
-        Value(TuplePat([ "a"; "b" ]), TupleExpr([ Constant("1"); Constant("2") ]))
-
-        Value(
-            RecordPat([ RecordFieldPat("A", ConstantPat(Int(3))) ]),
-            RecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 5)) ])
-        )
-
-        Value(ListPat([ NamedPat("c"); NamedPat("d") ]), ListExpr([ String("a"); String("b") ]))
-
-        Value(StructTuplePat([ NamedPat("e"); NamedPat("f") ]), StructTupleExpr([ Int(1); Int(2) ]))
-
-        MatchExpr(Constant("System.Object()"), [ MatchClauseExpr(IsInstPat(String()), ConstantExpr(Int(12))) ])
-
-        Value(ListConsPat(NamedPat("g"), NamedPat("h")), ListExpr([ Int(1) ]))
-
     }
 }
 |> Gen.mkOak
@@ -58,7 +51,83 @@ Oak() {
 (*** include-output ***)
 
 (**
-## ParameterPat with Attributes
+## Tuple Patterns
+`TuplePat` destructures a tuple; `StructTuplePat` destructures a struct tuple:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Value(TuplePat([ "a"; "b" ]), TupleExpr([ Constant("1"); Constant("2") ]))
+
+        Value(StructTuplePat([ NamedPat("e"); NamedPat("f") ]), StructTupleExpr([ Int(1); Int(2) ]))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## List Patterns
+`ListPat` matches a list of elements; `ListConsPat` matches head-and-tail:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Value(ListPat([ NamedPat("c"); NamedPat("d") ]), ListExpr([ String("a"); String("b") ]))
+
+        Value(ListConsPat(NamedPat("g"), NamedPat("h")), ListExpr([ Int(1) ]))
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Record Patterns
+`RecordPat` destructures a record by field with `RecordFieldPat`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Value(
+            RecordPat([ RecordFieldPat("A", ConstantPat(Int(3))) ]),
+            RecordExpr([ RecordFieldExpr("A", ConstantExpr(Int 5)) ])
+        )
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Type-test Patterns
+`IsInstPat` matches when the value is an instance of a given type — typically in
+a `match` clause:
+*)
+
+Oak() {
+    AnonymousModule() {
+        MatchExpr(Constant("System.Object()"), [ MatchClauseExpr(IsInstPat(String()), ConstantExpr(Int(12))) ])
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Parameter Patterns with Attributes
 You can add attributes to parameter patterns using the `.attribute()` or `.attributes()` modifiers.
 This is useful for adding attributes to constructor parameters or method parameters.
 *)


### PR DESCRIPTION
The Expressions and Patterns pages were each a single undocumented `Oak() { … }` dump (~40 and ~10 widgets with no headings or prose).

Reorganized into sections grouped by family — Expressions: identifiers/literals, collections/tuples, application/operators, lambdas, conditionals & matching, loops, exception handling, other; Patterns: named/or/as/ands, tuple, list, record, type-test, parameter-with-attributes — each with a short explanation, keeping the verified examples.

All examples evaluate under `dotnet fsdocs build --eval --strict`.

Batch 2 of the doc-gap effort (follows #197).