### PR TITLE
docs: flesh out Interfaces, Open Declarations, and Units of Measure

### DIFF
--- a/docs/widgets/Interfaces.fsx
+++ b/docs/widgets/Interfaces.fsx
@@ -8,35 +8,17 @@ index: 11
 
 (**
 # Interfaces
-Interfaces specify sets of related members that other classes implement.
 
-For details on how the AST node works, please refer to the [Fantomas Core documentation](https://fsprojects.github.io/fantomas/reference/fantomas-core-syntaxoak-typedefnregularnode.html).
-See also official [documentation](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/interfaces) for a comparison between the two.
-*)
+Interfaces specify sets of related members that other classes implement. Define
+one as a `TypeDefn` whose members are `AbstractMember`s, and implement it on a
+type with `InterfaceWith`.
 
-(**
-### Constructors
+See the official [F# interfaces documentation](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/interfaces) for background.
 
-| Constructors                       | Description                                           |
-|------------------------------------| ----------------------------------------------------- |
-| TypeDefn(name: string, parameters: WidgetBuilder<Pattern>)                  | Creates a TypeDefnRegularNode AST node with the specified name and parameters. |
-| TypeDefn(name: string, constructor: WidgetBuilder<ImplicitConstructorNode>)          | Creates a TypeDefnRegularNode AST node with the specified name and constructor. |
-| TypeDefn(name: string)                        | Creates a TypeDefnRegularNode AST node with the specified name. |
-*)
-
-(**
-### Modifiers
-
-| Modifier                                   | Description                                                                                     |
-|--------------------------------------------|-------------------------------------------------------------------------------------------------|
-| toRecursive() | Adds a scalar indicating that the type definition is recursive.                                         |
-| toPrivate()   | Sets the accessibility to the type definition to private.                                               |
-| toPublic()    | Sets the accessibility of the type definition to public.                                                |
-| toInternal()  | Sets the accessibility of the type definition to internal.                                               |
-| typeParams(typeParams: WidgetBuilder<TyparDecls>)  | Adds type parameters to the type definition.                                                         |
-| xmlDocs(xmlDocs: string list) | Adds XML documentation comments to the type definition.                                                |
-| attributes(attributes: WidgetBuilder<AttributeNode> list) | Adds multiple attributes to the type definition.                                                        |
-| attribute(attribute: WidgetBuilder<AttributeNode>) | Adds a single attribute to the type definition.                                                         |
+## Contents
+- [Defining an Interface](#defining-an-interface)
+- [Abstract Members with Parameters](#abstract-members-with-parameters)
+- [Implementing an Interface](#implementing-an-interface)
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -46,17 +28,48 @@ See also official [documentation](https://learn.microsoft.com/en-us/dotnet/fshar
 open Fabulous.AST
 open type Fabulous.AST.Ast
 
-Oak() {
+(**
+## Defining an Interface
+An interface is a type containing only abstract members:
+*)
 
+Oak() { AnonymousModule() { TypeDefn("INumeric") { AbstractMember("Add", [ Int(); Int() ], Int()) } } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Abstract Members with Parameters
+`AbstractMember` accepts named or unnamed parameter types and a return type. The
+trailing `true` requests the .NET-style tupled signature:
+*)
+
+Oak() {
     AnonymousModule() {
         TypeDefn("ISprintable") { AbstractMember("Print", [ ("format", Int()) ], Unit()) }
-        |> _.triviaBefore(SingleLine("Interfaces specify sets of related members that other classes implement."))
-
-        TypeDefn("INumericFSharp") { AbstractMember("Add", [ Int(); Int() ], Int()) }
 
         TypeDefn("INumericDotNet") { AbstractMember("Add", [ Int(); Int() ], Int(), true) }
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
-        TypeDefn("SomeClass1", ParenPat(TuplePat([ ParameterPat("x", Int()); ParameterPat("y", Float()) ]))) {
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Implementing an Interface
+Implement an interface on a class with `InterfaceWith`, supplying the concrete
+members:
+*)
+
+Oak() {
+    AnonymousModule() {
+        TypeDefn("SomeClass", ParenPat(TuplePat([ ParameterPat("x", Int()); ParameterPat("y", Float()) ]))) {
             InterfaceWith("IPrintable") {
                 Member("this.Print()", AppExpr("printfn", [ String("%d %f"); Constant("x"); Constant("y") ]))
             }

--- a/docs/widgets/OpenDeclarations.fsx
+++ b/docs/widgets/OpenDeclarations.fsx
@@ -7,21 +7,17 @@ index: 10
 *)
 
 (**
-# Open declarations
-An import declaration specifies a module or namespace whose elements you can reference without using a fully qualified name.
+# Open Declarations
 
-For details on how the AST node works, please refer to the [Fantomas Core documentation](https://fsprojects.github.io/fantomas/reference/fantomas-core-syntaxoak-openlistnode.html).
+An open declaration lets you reference the elements of a module or namespace
+without a fully qualified name. `Open` imports a namespace or module, `OpenType`
+imports a type's static members, and `OpenGlobal` opens from the root with the
+`global` specifier.
 
-*)
-(**
-### Constructors
-
-| Constructors                       | Description                                           |
-|------------------------------------| ----------------------------------------------------- |
-| Open(values: string list)                              | Creates an OpenListNode AST node |
-| Open(value: string)                                   | Creates an OpenListNode AST node  |
-| OpenType(values: string)                              | Creates an OpenListNode AST node  |
-| OpenType(value: string)                               | Creates an OpenListNode AST node  |
+## Contents
+- [Opening Namespaces and Modules](#opening-namespaces-and-modules)
+- [Opening a Type](#opening-a-type)
+- [Global Opens](#global-opens)
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -31,24 +27,49 @@ For details on how the AST node works, please refer to the [Fantomas Core docume
 open Fabulous.AST
 open type Fabulous.AST.Ast
 
+(**
+## Opening Namespaces and Modules
+Pass a single name or a list of path segments:
+*)
+
 Oak() {
     AnonymousModule() {
-        Open([ "System"; "IO" ]).triviaBefore(SingleLine("Open a .NET Framework namespace."))
+        Open("Fabulous.AST")
 
-        Open("Fabulous.AST").triviaAfter(Newline())
-
-        OpenType([ "System.Math" ])
-            .triviaBefore(SingleLine("This will expose all accessible static fields and members on the type."))
-            .triviaAfter(Newline())
-
-        OpenGlobal("A").triviaBefore(SingleLine("Open from root path only with global specifier"))
-
-        OpenGlobal("B")
-        OpenGlobal([ "A"; "B" ])
-
+        Open([ "System"; "IO" ])
     }
-    |> _.triviaBefore(SingleLine("Import declarations: The open keyword"))
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
 
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Opening a Type
+`OpenType` exposes the accessible static members and fields of a type:
+*)
+
+Oak() { AnonymousModule() { OpenType([ "System.Math" ]) } }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Global Opens
+`OpenGlobal` opens from the root path only, emitting the `global` specifier:
+*)
+
+Oak() {
+    AnonymousModule() {
+        OpenGlobal("A")
+
+        OpenGlobal([ "A"; "B" ])
+    }
 }
 |> Gen.mkOak
 |> Gen.run

--- a/docs/widgets/UnitsofMeasure.fsx
+++ b/docs/widgets/UnitsofMeasure.fsx
@@ -8,6 +8,15 @@ index: 14
 
 (**
 # Units of Measure
+
+Units of measure let you annotate numeric types with physical units that the
+compiler checks. Declare a measure with `Measure`, and attach one to a literal
+with `ConstantMeasure`.
+
+## Contents
+- [Defining a Measure](#defining-a-measure)
+- [Derived Measures](#derived-measures)
+- [Using a Measure](#using-a-measure)
 *)
 
 #r "../../src/Fabulous.AST/bin/Release/netstandard2.1/publish/Fantomas.Core.dll"
@@ -17,21 +26,51 @@ index: 14
 open Fabulous.AST
 open type Fabulous.AST.Ast
 
+(**
+## Defining a Measure
+A bare `Measure` declares a base unit:
+*)
+
 Oak() {
     AnonymousModule() {
         Measure("cm")
-
-        Measure("ml", MeasurePowerType("cm", Integer "3"))
-
-        Measure("m")
-
-        Measure("s")
-
         Measure("kg")
+        Measure("s")
+    }
+}
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Derived Measures
+Build derived measures from powers and products of existing ones with
+`MeasurePowerType`, `AppPrefix`, and `Tuple`:
+*)
+
+Oak() {
+    AnonymousModule() {
+        Measure("ml", MeasurePowerType("cm", Integer "3"))
 
         Measure("N", Tuple([ AppPrefix(LongIdent "kg", LongIdent "m"); MeasurePowerType("s", Integer "2") ], "/"))
     }
 }
+|> Gen.mkOak
+|> Gen.run
+|> printfn "%s"
+
+// produces the following code:
+(*** include-output ***)
+
+(**
+## Using a Measure
+Annotate a numeric literal with `ConstantMeasure`:
+*)
+
+Oak() { AnonymousModule() { Value("length", ConstantExpr(ConstantMeasure("10.0", MeasureSingle("cm")))) } }
 |> Gen.mkOak
 |> Gen.run
 |> printfn "%s"


### PR DESCRIPTION
These three pages were thin stubs — API tables or a single code-dump with no explanation. Restructured each into sectioned, explained docs:

- **Interfaces** — defining an interface, abstract members with parameters, implementing with `InterfaceWith`
- **Open Declarations** — `Open` (namespaces/modules), `OpenType`, `OpenGlobal`
- **Units of Measure** — base measures, derived measures (powers/products), and using a measure via `ConstantMeasure`

All examples evaluate under `dotnet fsdocs build --eval --strict`.

Batch 3 (final) of the doc-gap effort (follows #197, #198).