### PR TITLE
chore: cut 2.0.0-pre08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes_
+
+## [2.0.0-pre08] - 2026-06-01
+
 ### Added
 - `Gen.parse` round-trips a widget (or a source string) through Fantomas's F# parser and returns the rendered source when it is syntactically valid, or the parser diagnostics (one per line) otherwise — for catching widget combinations that produce invalid F# (#191)
 - `Rewrite.expr` / `Rewrite.exprInOak` and `Rewrite.typeDefn` / `Rewrite.typeDefnInOak`: curried, pipeline-friendly bottom-up rewriters that apply a transform to every expression (or type definition) reachable from an Oak — e.g. rename a call site everywhere, or convert a single-case union to a record (#189)
@@ -18,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Abstract member accessors no longer emit accessibility modifiers, which F# forbids on abstract slots (`abstract Y: int with get, set` rather than the invalid `with public get, public set`) (#194)
-- JSON field names containing backticks now replace them with underscores instead of producing an invalid nested-backtick identifier (#195)
 
 ### Removed
 - **Breaking:** `getterAccessibility` / `setterAccessibility` parameters on `AbstractMember` — they rendered invalid F#, since abstract slots always have the enclosing type's visibility (#194)

--- a/extensions/Fabulous.AST.Build/CHANGELOG.md
+++ b/extensions/Fabulous.AST.Build/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-pre08] - 2026-06-01
+
+### Changed
+- No changes
+
 ## [2.0.0-pre07] - 2026-05-30
 
 ### Changed

--- a/extensions/Fabulous.AST.Json/CHANGELOG.md
+++ b/extensions/Fabulous.AST.Json/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-pre08] - 2026-06-01
+
+### Fixed
+- JSON field names containing backticks now replace them with underscores instead of producing an invalid nested-backtick identifier (#195)
+
 ## [2.0.0-pre07] - 2026-05-30
 
 ### Changed


### PR DESCRIPTION
Prepares the `2.0.0-pre08` release notes.

- **Fabulous.AST** — moves the Unreleased entries to `[2.0.0-pre08]`: `Gen.parse`, `Rewrite.expr`/`typeDefn`, `producesValid`; breaking `Gen` module→type / `runWith`→`run` overload and record field accessibility; abstract-accessor fix; `AbstractMember` accessibility params removed.
- **Fabulous.AST.Json** — JSON backtick field-name fix (#195).
- **Fabulous.AST.Build** — no changes.

Merge this, then push the `2.0.0-pre08` tag to trigger the release workflow (pack + publish to NuGet).